### PR TITLE
feat(auth): add manual auth with role-based access control

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 
 class AuthController extends Controller
@@ -22,21 +24,44 @@ class AuthController extends Controller
     public function login(Request $request): RedirectResponse
     {
         $dataLogin = $request->validate([
-            'email' => ['required', 'email'],
+            'username' => ['required', 'string'],
             'password' => ['required', 'string'],
         ]);
 
         if (! Auth::attempt($dataLogin, $request->boolean('remember'))) {
             return back()
-                ->withInput($request->only('email'))
+                ->withInput($request->only('username'))
                 ->withErrors([
-                    'email' => 'Email atau password tidak valid.',
+                    'username' => 'Username atau password tidak valid.',
                 ]);
         }
 
         $request->session()->regenerate();
 
-        return redirect()->route('dashboard.index');
+        return $this->redirectToRoleHome();
+    }
+
+    public function register(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'username' => ['required', 'string', 'max:50', 'alpha_dash:ascii', 'unique:users,username'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+            'role' => ['required', Rule::in(['owner', 'gudang', 'kasir'])],
+        ]);
+
+        $data['email'] = $data['username'].'@toko.local';
+
+        User::create($data);
+
+        return redirect()
+            ->route('users.index')
+            ->with('status', 'Pengguna berhasil dibuat.');
+    }
+
+    public function redirectAuthenticatedUser(): RedirectResponse
+    {
+        return $this->redirectToRoleHome();
     }
 
     public function logout(Request $request): RedirectResponse
@@ -47,5 +72,15 @@ class AuthController extends Controller
         $request->session()->regenerateToken();
 
         return redirect()->route('login');
+    }
+
+    private function redirectToRoleHome(): RedirectResponse
+    {
+        return match (Auth::user()?->role) {
+            'owner' => redirect()->route('dashboard.index'),
+            'gudang' => redirect()->route('stocks.role-home'),
+            'kasir' => redirect()->route('transactions.pos'),
+            default => redirect()->route('login'),
+        };
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,6 +14,7 @@ class User extends Authenticatable
 
     protected $fillable = [
         'name',
+        'username',
         'email',
         'password',
         'role',

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -25,6 +25,7 @@ class UserFactory extends Factory
     {
         return [
             'name' => fake()->name(),
+            'username' => fake()->unique()->userName(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),

--- a/database/migrations/2026_04_20_000001_add_username_to_users_table.php
+++ b/database/migrations/2026_04_20_000001_add_username_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('username')->nullable()->unique()->after('name');
+        });
+
+        DB::table('users')
+            ->whereNull('username')
+            ->eachById(function (object $user): void {
+                DB::table('users')
+                    ->where('id', $user->id)
+                    ->update(['username' => 'user'.$user->id]);
+            });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropUnique(['username']);
+            $table->dropColumn('username');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -10,14 +10,20 @@ class DatabaseSeeder extends Seeder
 {
     public function run(): void
     {
-        User::updateOrCreate(
-            ['email' => 'admin@inventori.test'],
-            [
-                'name' => 'Admin Utama',
-                'password' => Hash::make('admin12345'),
-                'role' => 'owner',
-                'email_verified_at' => now(),
-            ]
-        );
+        $owner = User::query()
+            ->where('username', 'owner')
+            ->orWhereIn('email', ['owner@toko.com', 'owner@toko.local'])
+            ->firstOrNew();
+
+        $owner->fill([
+            'name' => 'Owner Toko',
+            'username' => 'owner',
+            'email' => 'owner@toko.local',
+            'password' => Hash::make('password'),
+            'role' => 'owner',
+            'email_verified_at' => now(),
+        ]);
+
+        $owner->save();
     }
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -54,13 +54,13 @@
             @csrf
 
             <div class="space-y-2">
-                <label for="email" class="block text-[0.72rem] font-bold uppercase tracking-[0.18em] text-slate-400">Email Owner</label>
+                <label for="username" class="block text-[0.72rem] font-bold uppercase tracking-[0.18em] text-slate-400">Username</label>
                 <input
-                    id="email"
-                    name="email"
-                    type="email"
-                    value="{{ old('email') }}"
-                    placeholder="owner@sitori.app"
+                    id="username"
+                    name="username"
+                    type="text"
+                    value="{{ old('username') }}"
+                    placeholder="owner"
                     class="h-[3.25rem] w-full rounded-xl border border-slate-200 bg-slate-100 px-4 text-sm font-medium text-slate-700 outline-none transition placeholder:text-slate-400 focus:border-[#163760] focus:bg-white focus:ring-4 focus:ring-[#163760]/10"
                 />
             </div>
@@ -91,15 +91,12 @@
 
             <div class="relative pt-4 text-center">
                 <div class="absolute inset-x-0 top-1/2 border-t border-slate-200"></div>
-                <span class="relative bg-white px-4 text-[0.68rem] font-bold uppercase tracking-[0.18em] text-slate-400">Belum punya akun owner?</span>
+                <span class="relative bg-white px-4 text-[0.68rem] font-bold uppercase tracking-[0.18em] text-slate-400">Belum punya akun?</span>
             </div>
 
-            <a href="{{ route('register') }}" class="flex h-[3.25rem] w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 text-sm font-semibold text-[#163760] transition hover:border-[#163760]/30 hover:bg-slate-50">
-                Buat akun Sitori
-                <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                    <path d="M4.167 10h11.666m0 0-4.166-4.167M15.833 10l-4.166 4.167" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-            </a>
+            <p class="text-center text-sm font-semibold text-[#163760]">
+                Minta owner toko membuatkan akun dari menu pengguna.
+            </p>
         </form>
     </div>
 @endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -44,7 +44,15 @@
             <p class="text-sm leading-7 text-slate-500 sm:text-base">Isi data dasar toko dan owner untuk memulai workspace Sitori.</p>
         </div>
 
-        <form class="mt-8 space-y-5">
+        @if ($errors->any())
+            <div class="mt-6 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 shadow-sm">
+                {{ $errors->first() }}
+            </div>
+        @endif
+
+        <form action="{{ route('register.process') }}" method="POST" class="mt-8 space-y-5">
+            @csrf
+
             <div class="grid gap-5 sm:grid-cols-2">
                 <div class="space-y-2">
                     <label for="store_name" class="block text-[0.72rem] font-bold uppercase tracking-[0.18em] text-slate-400">Nama Toko</label>
@@ -58,26 +66,41 @@
                 </div>
 
                 <div class="space-y-2">
-                    <label for="owner_name" class="block text-[0.72rem] font-bold uppercase tracking-[0.18em] text-slate-400">Nama Owner</label>
+                    <label for="name" class="block text-[0.72rem] font-bold uppercase tracking-[0.18em] text-slate-400">Nama Pengguna</label>
                     <input
-                        id="owner_name"
-                        name="owner_name"
+                        id="name"
+                        name="name"
                         type="text"
-                        placeholder="nama pemilik toko"
+                        value="{{ old('name') }}"
+                        placeholder="nama pengguna"
                         class="h-[3.25rem] w-full rounded-xl border border-slate-200 bg-slate-100 px-4 text-sm font-medium text-slate-700 outline-none transition placeholder:text-slate-400 focus:border-[#163760] focus:bg-white focus:ring-4 focus:ring-[#163760]/10"
                     />
                 </div>
             </div>
 
             <div class="space-y-2">
-                <label for="register_email" class="block text-[0.72rem] font-bold uppercase tracking-[0.18em] text-slate-400">Email Administrator</label>
+                <label for="register_username" class="block text-[0.72rem] font-bold uppercase tracking-[0.18em] text-slate-400">Username</label>
                 <input
-                    id="register_email"
-                    name="email"
-                    type="email"
-                    placeholder="owner@sitori.app"
+                    id="register_username"
+                    name="username"
+                    type="text"
+                    value="{{ old('username') }}"
+                    placeholder="contoh: kasir01"
                     class="h-[3.25rem] w-full rounded-xl border border-slate-200 bg-slate-100 px-4 text-sm font-medium text-slate-700 outline-none transition placeholder:text-slate-400 focus:border-[#163760] focus:bg-white focus:ring-4 focus:ring-[#163760]/10"
                 />
+            </div>
+
+            <div class="space-y-2">
+                <label for="role" class="block text-[0.72rem] font-bold uppercase tracking-[0.18em] text-slate-400">Role</label>
+                <select
+                    id="role"
+                    name="role"
+                    class="h-[3.25rem] w-full rounded-xl border border-slate-200 bg-slate-100 px-4 text-sm font-medium text-slate-700 outline-none transition focus:border-[#163760] focus:bg-white focus:ring-4 focus:ring-[#163760]/10"
+                >
+                    <option value="kasir" @selected(old('role') === 'kasir')>Kasir</option>
+                    <option value="gudang" @selected(old('role') === 'gudang')>Gudang</option>
+                    <option value="owner" @selected(old('role') === 'owner')>Owner</option>
+                </select>
             </div>
 
             <div class="grid gap-5 sm:grid-cols-2">
@@ -104,8 +127,8 @@
                 </div>
             </div>
 
-            <button type="button" class="h-[3.25rem] w-full rounded-xl bg-[#12345c] px-4 text-base font-semibold text-white shadow-[0_16px_30px_rgba(18,52,92,0.22)] transition hover:bg-[#102f53] focus:outline-none focus:ring-4 focus:ring-[#163760]/15">
-                Daftarkan Akun Owner
+            <button type="submit" class="h-[3.25rem] w-full rounded-xl bg-[#12345c] px-4 text-base font-semibold text-white shadow-[0_16px_30px_rgba(18,52,92,0.22)] transition hover:bg-[#102f53] focus:outline-none focus:ring-4 focus:ring-[#163760]/15">
+                Daftarkan Akun
             </button>
 
             <div class="relative pt-6 text-center">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -14,16 +14,26 @@
                 <p class="mt-2 text-sm text-slate-300">Skeleton Laravel 12</p>
             </div>
 
+            @php($role = auth()->user()?->role)
             <nav class="space-y-2 text-sm">
-                <a href="{{ route('dashboard.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Dashboard</a>
-                <a href="{{ route('products.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Produk</a>
-                <a href="{{ route('stocks.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Stok</a>
-                <a href="{{ route('transactions.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Penjualan</a>
-                <a href="{{ route('purchases.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Pembelian</a>
-                <a href="{{ route('suppliers.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Supplier</a>
-                <a href="{{ route('reports.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Laporan</a>
-                <a href="{{ route('forecasts.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Prediksi</a>
-                <a href="{{ route('users.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Pengguna</a>
+                @if ($role === 'owner')
+                    <a href="{{ route('dashboard.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Dashboard</a>
+                @endif
+                @if (in_array($role, ['owner', 'gudang'], true))
+                    <a href="{{ route('products.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Produk</a>
+                    <a href="{{ route('stocks.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Stok</a>
+                    <a href="{{ route('purchases.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Pembelian</a>
+                    <a href="{{ route('suppliers.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Supplier</a>
+                @endif
+                @if (in_array($role, ['owner', 'kasir'], true))
+                    <a href="{{ route('transactions.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Penjualan</a>
+                @endif
+                @if ($role === 'owner')
+                    <a href="{{ route('reports.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Laporan</a>
+                    <a href="{{ route('forecasts.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Prediksi</a>
+                    <a href="{{ route('users.index') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Pengguna</a>
+                    <a href="{{ route('register') }}" class="block rounded-lg px-3 py-2 hover:bg-slate-800">Register User</a>
+                @endif
             </nav>
         </aside>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,22 +15,24 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function (): void {
     Route::get('/login', [AuthController::class, 'showLoginForm'])->name('login');
-    Route::get('/register', [AuthController::class, 'showRegisterForm'])->name('register');
     Route::post('/login', [AuthController::class, 'login'])->name('login.process');
 });
 
 Route::middleware('auth')->group(function (): void {
     Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
-    Route::redirect('/', '/dashboard');
-    Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard.index');
+    Route::get('/', [AuthController::class, 'redirectAuthenticatedUser'])->name('home');
 
     Route::middleware('role:owner')->group(function (): void {
+        Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard.index');
+        Route::get('/register', [AuthController::class, 'showRegisterForm'])->name('register');
+        Route::post('/register', [AuthController::class, 'register'])->name('register.process');
         Route::resource('users', UserController::class);
         Route::resource('reports', ReportController::class)->only(['index']);
         Route::resource('forecasts', ForecastController::class);
     });
 
     Route::middleware('role:owner,gudang')->group(function (): void {
+        Route::get('/stok', [StockController::class, 'index'])->name('stocks.role-home');
         Route::resource('categories', CategoryController::class);
         Route::resource('products', ProductController::class);
         Route::resource('stocks', StockController::class);

--- a/tests/Feature/AuthRoleTest.php
+++ b/tests/Feature/AuthRoleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Tests\TestCase;
+
+class AuthRoleTest extends TestCase
+{
+    public function test_owner_is_redirected_to_dashboard(): void
+    {
+        $response = $this->actingAs($this->userWithRole('owner'))->get('/');
+
+        $response->assertRedirect(route('dashboard.index'));
+    }
+
+    public function test_gudang_is_redirected_to_stok(): void
+    {
+        $response = $this->actingAs($this->userWithRole('gudang'))->get('/');
+
+        $response->assertRedirect(route('stocks.role-home'));
+    }
+
+    public function test_kasir_is_redirected_to_pos(): void
+    {
+        $response = $this->actingAs($this->userWithRole('kasir'))->get('/');
+
+        $response->assertRedirect(route('transactions.pos'));
+    }
+
+    public function test_register_page_is_only_available_for_owner(): void
+    {
+        $this->get('/register')->assertRedirect('/login');
+        $this->actingAs($this->userWithRole('kasir'))->get('/register')->assertForbidden();
+        $this->actingAs($this->userWithRole('owner'))->get('/register')->assertOk();
+    }
+
+    private function userWithRole(string $role): User
+    {
+        return new User([
+            'name' => ucfirst($role),
+            'username' => $role,
+            'email' => $role.'@toko.com',
+            'role' => $role,
+        ]);
+    }
+}

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -14,6 +14,6 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertRedirect('/login');
     }
 }


### PR DESCRIPTION
  - Add manual AuthController flow for login, logout, register, and role-based redirects
  - Add role-based login redirect for owner, gudang, and kasir
  - Protect register route so only owner can create new users
  - Protect application routes with role middleware based on user role
  - Add /stok route for gudang role home and /pos route for kasir role home
  - Add username-based login instead of email login
  - Add username column migration for users table
  - Update default owner seeder to use username owner and password password
  - Update login and register forms to use username
  - Hide sidebar menu items based on authenticated user's role
  - Add feature tests for role redirects and register access

  Penjelasan Singkat

  Saya ubah sistem auth supaya backend lebih sesuai role. Login sekarang tidak lagi pakai email, tapi pakai username. Akun default owner sekarang:

  Route register dipindahkan ke area yang hanya bisa diakses owner, jadi gudang/kasir tidak bisa membuka halaman register. Setelah login, sistem otomatis mengarahkan user berdasarkan role: owner ke dashboard, gudang ke stok, dan kasir ke POS.

  Saya juga menambahkan proteksi route memakai middleware role, sehingga akses halaman mengikuti role masing-masing user. Sidebar ikut disesuaikan agar user hanya melihat menu yang memang bisa dia akses.

  File Penting Yang Diubah

  - app/Http/Controllers/AuthController.php
  - app/Http/Middleware/RoleMiddleware.php
  - routes/web.php
  - database/seeders/DatabaseSeeder.php
  - app/Models/User.php
  - database/migrations/2026_04_20_000001_add_username_to_users_table.php
  - resources/views/auth/login.blade.php
  - resources/views/auth/register.blade.php
  - resources/views/layouts/app.blade.php
  - tests/Feature/AuthRoleTest.php