### PR TITLE
Update Manajemen Kategori & Supplier (Role-Based)

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -5,13 +5,15 @@ namespace App\Http\Controllers;
 use App\Models\Category;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Illuminate\View\View;
 
 class CategoryController extends Controller
 {
     public function index(): View
     {
-        return view('categories.index');
+        $categories = Category::all();
+        return view('categories.index', compact('categories'));
     }
 
     public function create(): View
@@ -21,7 +23,16 @@ class CategoryController extends Controller
 
     public function store(Request $request): RedirectResponse
     {
-        return redirect()->route('categories.index');
+        $validated = $request->validate([
+            'nama_kategori' => ['required', 'string', 'max:255', 'unique:categories,nama_kategori'],
+            'deskripsi' => ['nullable', 'string'],
+        ]);
+
+        $validated['slug'] = Str::slug($validated['nama_kategori']);
+
+        Category::create($validated);
+
+        return redirect()->route('categories.index')->with('success', 'Kategori berhasil ditambahkan.');
     }
 
     public function show(Category $category): View
@@ -36,11 +47,22 @@ class CategoryController extends Controller
 
     public function update(Request $request, Category $category): RedirectResponse
     {
-        return redirect()->route('categories.index');
+        $validated = $request->validate([
+            'nama_kategori' => ['required', 'string', 'max:255', 'unique:categories,nama_kategori,' . $category->id],
+            'deskripsi' => ['nullable', 'string'],
+        ]);
+
+        $validated['slug'] = Str::slug($validated['nama_kategori']);
+
+        $category->update($validated);
+
+        return redirect()->route('categories.index')->with('success', 'Kategori berhasil diperbarui.');
     }
 
     public function destroy(Category $category): RedirectResponse
     {
-        return redirect()->route('categories.index');
+        $category->delete();
+
+        return redirect()->route('categories.index')->with('success', 'Kategori berhasil dihapus.');
     }
 }

--- a/app/Http/Controllers/SupplierController.php
+++ b/app/Http/Controllers/SupplierController.php
@@ -11,7 +11,8 @@ class SupplierController extends Controller
 {
     public function index(): View
     {
-        return view('suppliers.index');
+        $suppliers = Supplier::all();
+        return view('suppliers.index', compact('suppliers'));
     }
 
     public function create(): View
@@ -21,7 +22,18 @@ class SupplierController extends Controller
 
     public function store(Request $request): RedirectResponse
     {
-        return redirect()->route('suppliers.index');
+        $validated = $request->validate([
+            'nama_supplier' => ['required', 'string', 'max:255'],
+            'nama_kontak' => ['required', 'string', 'max:255'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'telepon' => ['required', 'string', 'max:20'],
+            'alamat' => ['required', 'string'],
+            'keterangan' => ['nullable', 'string'],
+        ]);
+
+        Supplier::create($validated);
+
+        return redirect()->route('suppliers.index')->with('success', 'Supplier berhasil ditambahkan.');
     }
 
     public function show(Supplier $supplier): View
@@ -36,11 +48,25 @@ class SupplierController extends Controller
 
     public function update(Request $request, Supplier $supplier): RedirectResponse
     {
-        return redirect()->route('suppliers.index');
+        $validated = $request->validate([
+            'nama_supplier' => ['required', 'string', 'max:255'],
+            'nama_kontak' => ['required', 'string', 'max:255'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'telepon' => ['required', 'string', 'max:20'],
+            'alamat' => ['required', 'string'],
+            'keterangan' => ['nullable', 'string'],
+            'is_active' => ['boolean'],
+        ]);
+
+        $supplier->update($validated);
+
+        return redirect()->route('suppliers.index')->with('success', 'Supplier berhasil diperbarui.');
     }
 
     public function destroy(Supplier $supplier): RedirectResponse
     {
-        return redirect()->route('suppliers.index');
+        $supplier->delete();
+
+        return redirect()->route('suppliers.index')->with('success', 'Supplier berhasil dihapus.');
     }
 }

--- a/database/migrations/2026_04_26_000001_make_mode_app_nullable_on_users_table.php
+++ b/database/migrations/2026_04_26_000001_make_mode_app_nullable_on_users_table.php
@@ -1,13 +1,18 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
     public function up(): void
     {
-        DB::statement('ALTER TABLE users MODIFY mode_app VARCHAR(50) NULL DEFAULT NULL');
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('mode_app', 50)->nullable()->default(null)->change();
+        });
+
         DB::table('users')
             ->where('mode_app', 'toko')
             ->update(['mode_app' => null]);
@@ -15,6 +20,9 @@ return new class extends Migration
 
     public function down(): void
     {
-        DB::statement("ALTER TABLE users MODIFY mode_app VARCHAR(50) NOT NULL DEFAULT 'toko'");
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('mode_app', 50)->nullable(false)->default('toko')->change();
+        });
     }
 };
+

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,8 +22,8 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,6 +43,7 @@ Route::middleware('auth')->group(function (): void {
 
     Route::middleware('mode.access:inventory')->group(function (): void {
         Route::resource('categories', CategoryController::class);
+        Route::resource('suppliers', SupplierController::class);
         Route::resource('products', ProductController::class)->only(['create', 'store', 'edit', 'update', 'destroy']);
         Route::resource('stocks', StockController::class);
         Route::resource('forecasts', ForecastController::class);
@@ -54,7 +55,6 @@ Route::middleware('auth')->group(function (): void {
 
     Route::middleware('mode.access:warehouse')->group(function (): void {
         Route::resource('purchases', PurchaseController::class);
-        Route::resource('suppliers', SupplierController::class);
         Route::get('/stok/notifikasi', [StockController::class, 'index'])->name('stocks.notifications');
     });
 

--- a/tests/Feature/CategoryManagementRoleModeTest.php
+++ b/tests/Feature/CategoryManagementRoleModeTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CategoryManagementRoleModeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_can_access_and_crud_categories(): void
+    {
+        $owner = User::factory()->create([
+            'role' => 'owner',
+            'mode_app' => 'sederhana',
+        ]);
+
+        $this->actingAs($owner)->get('/categories')->assertOk();
+        $this->actingAs($owner)->get('/categories/create')->assertOk();
+
+        $this->actingAs($owner)
+            ->post('/categories', [
+                'nama_kategori' => 'Sembako',
+                'deskripsi' => 'Kategori sembako',
+            ])
+            ->assertRedirect(route('categories.index'));
+
+        $this->assertDatabaseHas('categories', [
+            'nama_kategori' => 'Sembako',
+            'slug' => 'sembako',
+        ]);
+
+        $category = Category::where('nama_kategori', 'Sembako')->first();
+
+        $this->actingAs($owner)->get(route('categories.edit', $category))->assertOk();
+
+        $this->actingAs($owner)
+            ->put(route('categories.update', $category), [
+                'nama_kategori' => 'Sembako Premium',
+            ])
+            ->assertRedirect(route('categories.index'));
+
+        $this->assertDatabaseHas('categories', [
+            'id' => $category->id,
+            'nama_kategori' => 'Sembako Premium',
+        ]);
+
+        $this->actingAs($owner)
+            ->delete(route('categories.destroy', $category))
+            ->assertRedirect(route('categories.index'));
+
+        $this->assertDatabaseMissing('categories', [
+            'id' => $category->id,
+        ]);
+    }
+
+    public function test_gudang_lengkap_can_crud_categories(): void
+    {
+        $gudang = User::factory()->create([
+            'role' => 'gudang',
+            'mode_app' => 'lengkap',
+        ]);
+
+        $category = Category::create([
+            'nama_kategori' => 'Minuman',
+            'slug' => 'minuman',
+        ]);
+
+        $this->actingAs($gudang)->get('/categories')->assertOk();
+        $this->actingAs($gudang)->get('/categories/create')->assertOk();
+        $this->actingAs($gudang)->get(route('categories.edit', $category))->assertOk();
+
+        $this->actingAs($gudang)
+            ->put(route('categories.update', $category), [
+                'nama_kategori' => 'Minuman Ringan',
+            ])
+            ->assertRedirect(route('categories.index'));
+
+        $this->assertDatabaseHas('categories', [
+            'id' => $category->id,
+            'nama_kategori' => 'Minuman Ringan',
+        ]);
+
+        $this->actingAs($gudang)
+            ->delete(route('categories.destroy', $category))
+            ->assertRedirect(route('categories.index'));
+
+        $this->assertDatabaseMissing('categories', [
+            'id' => $category->id,
+        ]);
+    }
+
+    public function test_gudang_sederhana_cannot_access_categories(): void
+    {
+        $gudang = User::factory()->create([
+            'role' => 'gudang',
+            'mode_app' => 'sederhana',
+        ]);
+
+        $category = Category::create([
+            'nama_kategori' => 'Snack',
+            'slug' => 'snack',
+        ]);
+
+        $this->actingAs($gudang)->get('/categories')->assertForbidden();
+        $this->actingAs($gudang)->get('/categories/create')->assertForbidden();
+        $this->actingAs($gudang)->post('/categories', ['nama_kategori' => 'Test'])->assertForbidden();
+        $this->actingAs($gudang)->get(route('categories.edit', $category))->assertForbidden();
+    }
+
+    public function test_kasir_cannot_access_categories(): void
+    {
+        $kasir = User::factory()->create([
+            'role' => 'kasir',
+            'mode_app' => 'lengkap',
+        ]);
+
+        $category = Category::create([
+            'nama_kategori' => 'Rokok',
+            'slug' => 'rokok',
+        ]);
+
+        $this->actingAs($kasir)->get('/categories')->assertForbidden();
+        $this->actingAs($kasir)->get('/categories/create')->assertForbidden();
+        $this->actingAs($kasir)->post('/categories', ['nama_kategori' => 'Test'])->assertForbidden();
+        $this->actingAs($kasir)->get(route('categories.edit', $category))->assertForbidden();
+        $this->actingAs($kasir)->put(route('categories.update', $category), ['nama_kategori' => 'Test2'])->assertForbidden();
+        $this->actingAs($kasir)->delete(route('categories.destroy', $category))->assertForbidden();
+    }
+
+    public function test_category_validation_requires_unique_name(): void
+    {
+        $owner = User::factory()->create([
+            'role' => 'owner',
+            'mode_app' => 'lengkap',
+        ]);
+
+        Category::create([
+            'nama_kategori' => 'Sayuran',
+            'slug' => 'sayuran',
+        ]);
+
+        $this->actingAs($owner)
+            ->from('/categories/create')
+            ->post('/categories', [
+                'nama_kategori' => '', // Empty
+            ])
+            ->assertRedirect('/categories/create')
+            ->assertSessionHasErrors(['nama_kategori']);
+
+        $this->actingAs($owner)
+            ->from('/categories/create')
+            ->post('/categories', [
+                'nama_kategori' => 'Sayuran', // Duplicate
+            ])
+            ->assertRedirect('/categories/create')
+            ->assertSessionHasErrors(['nama_kategori']);
+    }
+}

--- a/tests/Feature/SupplierManagementRoleModeTest.php
+++ b/tests/Feature/SupplierManagementRoleModeTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Supplier;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SupplierManagementRoleModeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_can_access_and_crud_suppliers_in_any_mode(): void
+    {
+        $owner = User::factory()->create([
+            'role' => 'owner',
+            'mode_app' => 'sederhana',
+        ]);
+
+        $this->actingAs($owner)->get('/suppliers')->assertOk();
+        $this->actingAs($owner)->get('/suppliers/create')->assertOk();
+
+        $this->actingAs($owner)
+            ->post('/suppliers', [
+                'nama_supplier' => 'PT Sumber Rejeki',
+                'nama_kontak' => 'Budi',
+                'telepon' => '081234567890',
+                'alamat' => 'Jl. Raya No. 1',
+            ])
+            ->assertRedirect(route('suppliers.index'));
+
+        $this->assertDatabaseHas('suppliers', [
+            'nama_supplier' => 'PT Sumber Rejeki',
+        ]);
+
+        $supplier = Supplier::where('nama_supplier', 'PT Sumber Rejeki')->first();
+
+        $this->actingAs($owner)->get(route('suppliers.edit', $supplier))->assertOk();
+
+        $this->actingAs($owner)
+            ->put(route('suppliers.update', $supplier), [
+                'nama_supplier' => 'PT Sumber Rejeki Jaya',
+                'nama_kontak' => 'Budi',
+                'telepon' => '081234567890',
+                'alamat' => 'Jl. Raya No. 1',
+            ])
+            ->assertRedirect(route('suppliers.index'));
+
+        $this->assertDatabaseHas('suppliers', [
+            'id' => $supplier->id,
+            'nama_supplier' => 'PT Sumber Rejeki Jaya',
+        ]);
+
+        $this->actingAs($owner)
+            ->delete(route('suppliers.destroy', $supplier))
+            ->assertRedirect(route('suppliers.index'));
+
+        $this->assertDatabaseMissing('suppliers', [
+            'id' => $supplier->id,
+        ]);
+    }
+
+    public function test_gudang_lengkap_can_crud_suppliers(): void
+    {
+        $gudang = User::factory()->create([
+            'role' => 'gudang',
+            'mode_app' => 'lengkap',
+        ]);
+
+        $supplier = Supplier::create([
+            'nama_supplier' => 'CV Makmur',
+            'nama_kontak' => 'Andi',
+            'telepon' => '08987654321',
+            'alamat' => 'Jl. Merdeka 2',
+        ]);
+
+        $this->actingAs($gudang)->get('/suppliers')->assertOk();
+        $this->actingAs($gudang)->get('/suppliers/create')->assertOk();
+        $this->actingAs($gudang)->get(route('suppliers.edit', $supplier))->assertOk();
+
+        $this->actingAs($gudang)
+            ->put(route('suppliers.update', $supplier), [
+                'nama_supplier' => 'CV Makmur Sejahtera',
+                'nama_kontak' => 'Andi',
+                'telepon' => '08987654321',
+                'alamat' => 'Jl. Merdeka 2',
+            ])
+            ->assertRedirect(route('suppliers.index'));
+
+        $this->assertDatabaseHas('suppliers', [
+            'id' => $supplier->id,
+            'nama_supplier' => 'CV Makmur Sejahtera',
+        ]);
+
+        $this->actingAs($gudang)
+            ->delete(route('suppliers.destroy', $supplier))
+            ->assertRedirect(route('suppliers.index'));
+
+        $this->assertDatabaseMissing('suppliers', [
+            'id' => $supplier->id,
+        ]);
+    }
+
+    public function test_gudang_sederhana_cannot_access_suppliers(): void
+    {
+        $gudang = User::factory()->create([
+            'role' => 'gudang',
+            'mode_app' => 'sederhana',
+        ]);
+
+        $supplier = Supplier::create([
+            'nama_supplier' => 'UD Maju',
+            'nama_kontak' => 'Cici',
+            'telepon' => '08777777',
+            'alamat' => 'Jl. Sudirman 3',
+        ]);
+
+        $this->actingAs($gudang)->get('/suppliers')->assertForbidden();
+        $this->actingAs($gudang)->get('/suppliers/create')->assertForbidden();
+        $this->actingAs($gudang)->post('/suppliers', [])->assertForbidden();
+        $this->actingAs($gudang)->get(route('suppliers.edit', $supplier))->assertForbidden();
+    }
+
+    public function test_kasir_cannot_access_suppliers(): void
+    {
+        $kasir = User::factory()->create([
+            'role' => 'kasir',
+            'mode_app' => 'lengkap',
+        ]);
+
+        $supplier = Supplier::create([
+            'nama_supplier' => 'Toko Laris',
+            'nama_kontak' => 'Dodi',
+            'telepon' => '08555555',
+            'alamat' => 'Jl. Diponegoro 4',
+        ]);
+
+        $this->actingAs($kasir)->get('/suppliers')->assertForbidden();
+        $this->actingAs($kasir)->get('/suppliers/create')->assertForbidden();
+        $this->actingAs($kasir)->post('/suppliers', [])->assertForbidden();
+        $this->actingAs($kasir)->get(route('suppliers.edit', $supplier))->assertForbidden();
+        $this->actingAs($kasir)->put(route('suppliers.update', $supplier), [])->assertForbidden();
+        $this->actingAs($kasir)->delete(route('suppliers.destroy', $supplier))->assertForbidden();
+    }
+
+    public function test_supplier_validation_requires_minimum_fields(): void
+    {
+        $owner = User::factory()->create([
+            'role' => 'owner',
+            'mode_app' => 'lengkap',
+        ]);
+
+        $this->actingAs($owner)
+            ->from('/suppliers/create')
+            ->post('/suppliers', [])
+            ->assertRedirect('/suppliers/create')
+            ->assertSessionHasErrors(['nama_supplier', 'nama_kontak', 'telepon', 'alamat']);
+    }
+}


### PR DESCRIPTION
 Update Manajemen Kategori & Supplier (Role-Based)

   * Manajemen Kategori:
       * Membatasi akses CRUD Kategori hanya untuk Owner (semua mode) dan Admin Gudang (mode lengkap).
       * Memblokir akses Kasir ke halaman Kategori.
       * Menambahkan validasi di backend: nama_kategori wajib diisi, tidak boleh duplikat, dan otomatis menghasilkan
         slug.
   * Manajemen Supplier:
       * Memindahkan rute Supplier ke grup middleware inventory.
       * Membatasi akses CRUD Supplier hanya untuk Owner dan Admin Gudang (mode lengkap). Kasir tidak memiliki
         akses.
       * Menambahkan validasi backend untuk kolom wajib: nama_supplier, nama_kontak, telepon, dan alamat.
   * Testing:
       * Menambahkan dan memastikan semua Feature Test untuk pembatasan peran (role) dan validasi pada Kategori dan
         Supplier berjalan sukses (100% Passed) menggunakan SQLite In-Memory.