### PR TITLE
Implementasi Notifikasi Stok Menipis & Rapikan Transaksi Penjualan POS dan Update Stok Otomatis

### DIFF
--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -13,21 +13,12 @@ class StockController extends Controller
 {
     public function index(): View
     {
-        $products = Product::query()
-            ->with(['kategori', 'supplier'])
-            ->orderBy('nama_produk')
-            ->get();
+        return $this->stockListingView();
+    }
 
-        $movements = StockMovement::query()
-            ->with(['produk', 'pengguna'])
-            ->latest('tanggal_pergerakan')
-            ->paginate(10);
-
-        return view('stocks.index', [
-            'products' => $products,
-            'movements' => $movements,
-            'canManageStock' => $this->canManageStock(request()->user()?->role, request()->user()?->mode_app),
-        ]);
+    public function notifications(): View
+    {
+        return $this->stockListingView(true);
     }
 
     public function create(): View
@@ -83,6 +74,27 @@ class StockController extends Controller
     public function destroy(StockMovement $stock): RedirectResponse
     {
         return redirect()->route('stocks.index');
+    }
+
+    private function stockListingView(bool $showLowStockOnly = false): View
+    {
+        $products = Product::query()
+            ->with(['kategori', 'supplier'])
+            ->when($showLowStockOnly, fn ($query) => $query->whereColumn('stok', '<=', 'stok_minimum'))
+            ->orderBy('nama_produk')
+            ->get();
+
+        $movements = StockMovement::query()
+            ->with(['produk', 'pengguna'])
+            ->latest('tanggal_pergerakan')
+            ->paginate(10);
+
+        return view('stocks.index', [
+            'products' => $products,
+            'movements' => $movements,
+            'canManageStock' => $this->canManageStock(request()->user()?->role, request()->user()?->mode_app),
+            'showLowStockOnly' => $showLowStockOnly,
+        ]);
     }
 
     private function canManageStock(?string $role, ?string $modeApp): bool

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -18,6 +18,10 @@ class TransactionController extends Controller
     {
         $transactions = Transaction::query()
             ->with('kasir')
+            ->when(
+                request()->user()?->role === 'kasir',
+                fn ($query) => $query->where('user_id', request()->user()->id),
+            )
             ->latest('tanggal_transaksi')
             ->paginate(10);
 
@@ -129,6 +133,10 @@ class TransactionController extends Controller
 
     public function show(Transaction $transaction): View
     {
+        if (request()->user()?->role === 'kasir' && $transaction->user_id !== request()->user()?->id) {
+            abort(403, 'Anda tidak memiliki akses ke transaksi ini.');
+        }
+
         $transaction->load(['kasir', 'detailItem']);
 
         return view('transactions.show', compact('transaction'));

--- a/app/Http/Middleware/EnsureRoleModeAccess.php
+++ b/app/Http/Middleware/EnsureRoleModeAccess.php
@@ -28,6 +28,7 @@ class EnsureRoleModeAccess
         $bolehAkses = match ($access) {
             'owner' => $pengguna->role === 'owner',
             'stock-read' => $this->canReadStock($pengguna->role, $pengguna->mode_app),
+            'low-stock' => $this->canAccessLowStockNotifications($pengguna->role, $pengguna->mode_app),
             'inventory' => $this->canAccessInventory($pengguna->role, $pengguna->mode_app),
             'warehouse' => $this->canAccessWarehouse($pengguna->role, $pengguna->mode_app),
             'sales' => $this->canAccessSales($pengguna->role, $pengguna->mode_app),
@@ -51,6 +52,15 @@ class EnsureRoleModeAccess
     }
 
     private function canAccessInventory(string $role, ?string $modeApp): bool
+    {
+        return match ($role) {
+            'owner' => in_array($modeApp, ['sederhana', 'lengkap'], true),
+            'gudang' => $modeApp === 'lengkap',
+            default => false,
+        };
+    }
+
+    private function canAccessLowStockNotifications(string $role, ?string $modeApp): bool
     {
         return match ($role) {
             'owner' => in_array($modeApp, ['sederhana', 'lengkap'], true),

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -36,6 +36,7 @@
                 ]
                 : [
                     ['label' => 'Dashboard', 'route' => 'dashboard.index', 'icon' => 'dashboard'],
+                    ['label' => 'Produk', 'route' => 'products.index', 'icon' => 'products'],
                     ['label' => 'Kategori', 'route' => 'categories.index', 'icon' => 'categories'],
                     ['label' => 'Stok', 'route' => 'stocks.role-home', 'icon' => 'stocks'],
                     ['label' => 'Laporan', 'route' => 'reports.index', 'icon' => 'reports'],
@@ -50,7 +51,6 @@
                     ['label' => 'Kategori', 'route' => 'categories.index', 'icon' => 'categories'],
                     ['label' => 'Supplier', 'route' => 'suppliers.index', 'icon' => 'supplier'],
                     ['label' => 'Pembelian', 'route' => 'purchases.index', 'icon' => 'purchase'],
-                    ['label' => 'Notifikasi Stok', 'route' => 'stocks.notifications', 'icon' => 'alert'],
                     ['label' => 'Prediksi Stok', 'route' => 'forecasts.index', 'icon' => 'forecast'],
                 ]
                 : [],
@@ -168,7 +168,7 @@
                                                 {{ $criticalProductsCount > 0 ? $criticalProductsCount . ' produk perlu perhatian' : 'Tidak ada stok kritis saat ini' }}
                                             </p>
                                         </div>
-                                        <a href="{{ route('stocks.role-home') }}" class="text-xs font-semibold text-[#003441] transition hover:text-[#0f4c5c]">
+                                        <a href="{{ route('stocks.notifications') }}" class="text-xs font-semibold text-[#003441] transition hover:text-[#0f4c5c]">
                                             Lihat semua
                                         </a>
                                     </div>
@@ -176,7 +176,7 @@
                                 @if ($criticalProductsPreview->isNotEmpty())
                                     <div class="max-h-80 overflow-y-auto py-2">
                                         @foreach ($criticalProductsPreview as $criticalProduct)
-                                            <a href="{{ route('stocks.role-home') }}" class="flex items-start gap-3 px-4 py-3 transition hover:bg-[#f9f9fa]">
+                                            <a href="{{ route('stocks.notifications') }}" class="flex items-start gap-3 px-4 py-3 transition hover:bg-[#f9f9fa]">
                                                 <span class="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#ffdad6] text-[#ba1a1a]">
                                                     <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8.25v4.5m0 3h.01M10.04 4.72 3.56 15.53A1.5 1.5 0 0 0 4.85 17.8h14.3a1.5 1.5 0 0 0 1.29-2.27L13.96 4.72a1.5 1.5 0 0 0-2.92 0Z" />

--- a/resources/views/stocks/index.blade.php
+++ b/resources/views/stocks/index.blade.php
@@ -3,12 +3,15 @@
 @php
     $isSimpleMode = auth()->user()?->mode_app === 'sederhana';
     $lowStockCount = $products->filter(fn ($product) => $product->stok <= $product->stok_minimum)->count();
+    $showLowStockOnly = $showLowStockOnly ?? false;
 @endphp
 
 @section('page_title', 'Stok')
-@section('page_subtitle', $isSimpleMode
-    ? 'Pantau ringkasan stok barang, stok masuk/keluar, stok minimum, dan histori pergerakan stok sederhana.'
-    : 'Pantau data stok utama, stok minimum, histori pergerakan stok, dan kontrol stok lebih detail untuk owner mode lengkap.')
+@section('page_subtitle', $showLowStockOnly
+    ? 'Daftar produk dengan stok saat ini berada di bawah atau sama dengan batas minimum.'
+    : ($isSimpleMode
+        ? 'Pantau ringkasan stok barang, stok masuk/keluar, stok minimum, dan histori pergerakan stok sederhana.'
+        : 'Pantau data stok utama, stok minimum, histori pergerakan stok, dan kontrol stok lebih detail untuk owner mode lengkap.'))
 
 @section('page_actions')
     @if ($canManageStock)
@@ -28,9 +31,9 @@
 
         <section class="grid grid-cols-1 gap-4 lg:grid-cols-3">
             <article class="rounded-2xl border border-[#c0c8cb] bg-white p-6 shadow-sm">
-                <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Data Stok Utama</p>
+                <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">{{ $showLowStockOnly ? 'Produk Menipis' : 'Data Stok Utama' }}</p>
                 <h2 class="mt-2 text-3xl font-bold tracking-tight text-slate-900">{{ $products->count() }}</h2>
-                <p class="mt-2 text-sm text-slate-500">Produk yang sedang dimonitor pada inventory aktif.</p>
+                <p class="mt-2 text-sm text-slate-500">{{ $showLowStockOnly ? 'Produk yang perlu segera diprioritaskan untuk restock.' : 'Produk yang sedang dimonitor pada inventory aktif.' }}</p>
             </article>
             <article class="rounded-2xl border border-[#c0c8cb] bg-white p-6 shadow-sm">
                 <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Stok Minimum</p>
@@ -46,8 +49,12 @@
 
         <section class="overflow-hidden rounded-2xl border border-[#c0c8cb] bg-white shadow-sm">
             <div class="border-b border-[#c0c8cb] px-6 py-4">
-                <h2 class="text-lg font-semibold text-slate-900">Data Stok Utama</h2>
-                <p class="mt-1 text-sm text-slate-500">{{ $isSimpleMode ? 'Ringkasan stok barang dan stok minimum untuk pemantauan owner sehari-hari.' : 'Tabel stok aktif, stok minimum, supplier terkait, dan indikator produk yang perlu perhatian.' }}</p>
+                <h2 class="text-lg font-semibold text-slate-900">{{ $showLowStockOnly ? 'Daftar Stok Menipis' : 'Data Stok Utama' }}</h2>
+                <p class="mt-1 text-sm text-slate-500">
+                    {{ $showLowStockOnly
+                        ? 'Hanya produk dengan stok saat ini berada di bawah atau sama dengan stok minimum yang ditampilkan.'
+                        : ($isSimpleMode ? 'Ringkasan stok barang dan stok minimum untuk pemantauan owner sehari-hari.' : 'Tabel stok aktif, stok minimum, supplier terkait, dan indikator produk yang perlu perhatian.') }}
+                </p>
             </div>
             <div class="overflow-x-auto">
                 <table class="min-w-[920px] w-full text-left text-sm">
@@ -85,7 +92,9 @@
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="{{ $isSimpleMode ? '5' : '6' }}" class="px-6 py-8 text-center text-slate-500">Belum ada produk.</td>
+                                <td colspan="{{ $isSimpleMode ? '5' : '6' }}" class="px-6 py-8 text-center text-slate-500">
+                                    {{ $showLowStockOnly ? 'Tidak ada produk dengan stok menipis.' : 'Belum ada produk.' }}
+                                </td>
                             </tr>
                         @endforelse
                     </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -53,9 +53,12 @@ Route::middleware('auth')->group(function (): void {
         Route::resource('products', ProductController::class)->only(['show']);
     });
 
+    Route::middleware('mode.access:low-stock')->group(function (): void {
+        Route::get('/stok/notifikasi', [StockController::class, 'notifications'])->name('stocks.notifications');
+    });
+
     Route::middleware('mode.access:warehouse')->group(function (): void {
         Route::resource('purchases', PurchaseController::class);
-        Route::get('/stok/notifikasi', [StockController::class, 'index'])->name('stocks.notifications');
     });
 
     Route::middleware('mode.access:owner')->group(function (): void {

--- a/tests/Feature/LowStockNotificationTest.php
+++ b/tests/Feature/LowStockNotificationTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\Supplier;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LowStockNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_can_see_only_low_stock_products_in_notifications(): void
+    {
+        $owner = User::factory()->create([
+            'role' => 'owner',
+            'mode_app' => 'sederhana',
+        ]);
+
+        $criticalProduct = $this->createProduct([
+            'nama_produk' => 'Beras Kritis',
+            'stok' => 2,
+            'stok_minimum' => 2,
+        ]);
+
+        $safeProduct = $this->createProduct([
+            'nama_produk' => 'Gula Aman',
+            'stok' => 8,
+            'stok_minimum' => 2,
+        ]);
+
+        $this->actingAs($owner)
+            ->get(route('stocks.notifications'))
+            ->assertOk()
+            ->assertSee($criticalProduct->nama_produk)
+            ->assertDontSee($safeProduct->nama_produk)
+            ->assertSee('Daftar Stok Menipis');
+    }
+
+    public function test_gudang_lengkap_can_see_low_stock_notifications(): void
+    {
+        $gudang = User::factory()->create([
+            'role' => 'gudang',
+            'mode_app' => 'lengkap',
+        ]);
+
+        $criticalProduct = $this->createProduct([
+            'nama_produk' => 'Minyak Kritis',
+            'stok' => 1,
+            'stok_minimum' => 3,
+        ]);
+
+        $this->actingAs($gudang)
+            ->get(route('stocks.notifications'))
+            ->assertOk()
+            ->assertSee($criticalProduct->nama_produk);
+    }
+
+    public function test_kasir_cannot_access_low_stock_notifications(): void
+    {
+        $kasir = User::factory()->create([
+            'role' => 'kasir',
+            'mode_app' => 'sederhana',
+        ]);
+
+        $this->actingAs($kasir)
+            ->get(route('stocks.notifications'))
+            ->assertForbidden();
+    }
+
+    private function createProduct(array $attributes = []): Product
+    {
+        $category = Category::create([
+            'nama_kategori' => fake()->unique()->word(),
+            'slug' => fake()->unique()->slug(),
+            'is_active' => true,
+        ]);
+
+        $supplier = Supplier::create([
+            'nama_supplier' => fake()->unique()->company(),
+            'nama_kontak' => fake()->name(),
+            'telepon' => fake()->numerify('08##########'),
+            'alamat' => fake()->address(),
+            'is_active' => true,
+        ]);
+
+        return Product::create($attributes + [
+            'category_id' => $category->id,
+            'supplier_id' => $supplier->id,
+            'kode_produk' => 'PRD-'.fake()->unique()->numerify('####'),
+            'nama_produk' => 'Produk '.fake()->unique()->word(),
+            'slug' => fake()->unique()->slug(),
+            'satuan' => 'pcs',
+            'harga_beli' => 10000,
+            'harga_jual' => 15000,
+            'stok' => 0,
+            'stok_minimum' => 2,
+            'is_active' => true,
+        ]);
+    }
+}

--- a/tests/Feature/PosSalesTransactionTest.php
+++ b/tests/Feature/PosSalesTransactionTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\StockMovement;
+use App\Models\Supplier;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PosSalesTransactionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_kasir_can_create_sales_transaction_from_pos(): void
+    {
+        $kasir = User::factory()->create([
+            'role' => 'kasir',
+            'mode_app' => 'sederhana',
+        ]);
+        $product = $this->createProduct([
+            'stok' => 10,
+            'harga_jual' => 12000,
+        ]);
+
+        $response = $this->actingAs($kasir)
+            ->post('/transactions', [
+                'items' => [
+                    [
+                        'product_id' => $product->id,
+                        'qty' => 3,
+                    ],
+                ],
+                'nominal_bayar' => 40000,
+                'metode_pembayaran' => 'tunai',
+            ]);
+
+        $transaction = Transaction::query()->first();
+
+        $response->assertRedirect(route('transactions.show', $transaction));
+
+        $this->assertDatabaseHas('transactions', [
+            'id' => $transaction->id,
+            'user_id' => $kasir->id,
+            'total_item' => 3,
+            'subtotal' => 36000,
+            'total_bayar' => 36000,
+            'nominal_bayar' => 40000,
+            'kembalian' => 4000,
+            'status' => 'selesai',
+        ]);
+
+        $this->assertDatabaseHas('transaction_items', [
+            'transaction_id' => $transaction->id,
+            'product_id' => $product->id,
+            'qty' => 3,
+            'harga' => 12000,
+            'subtotal' => 36000,
+        ]);
+
+        $this->assertDatabaseHas('products', [
+            'id' => $product->id,
+            'stok' => 7,
+        ]);
+
+        $this->assertDatabaseHas('stock_movements', [
+            'product_id' => $product->id,
+            'user_id' => $kasir->id,
+            'jenis_pergerakan' => 'keluar',
+            'qty' => 3,
+            'stok_sebelum' => 10,
+            'stok_sesudah' => 7,
+            'referensi_tipe' => 'transaction',
+            'referensi_id' => $transaction->id,
+        ]);
+    }
+
+    public function test_transaction_fails_when_stock_is_insufficient(): void
+    {
+        $kasir = User::factory()->create([
+            'role' => 'kasir',
+            'mode_app' => 'sederhana',
+        ]);
+        $product = $this->createProduct(['stok' => 2]);
+
+        $this->actingAs($kasir)
+            ->from('/pos')
+            ->post('/transactions', [
+                'items' => [
+                    [
+                        'product_id' => $product->id,
+                        'qty' => 5,
+                    ],
+                ],
+            ])
+            ->assertRedirect('/pos')
+            ->assertSessionHasErrors('items');
+
+        $this->assertDatabaseHas('products', [
+            'id' => $product->id,
+            'stok' => 2,
+        ]);
+
+        $this->assertEquals(0, Transaction::query()->count());
+        $this->assertEquals(0, StockMovement::query()->count());
+    }
+
+    public function test_owner_can_access_pos_in_selected_mode(): void
+    {
+        $owner = User::factory()->create([
+            'role' => 'owner',
+            'mode_app' => 'sederhana',
+        ]);
+
+        $this->actingAs($owner)->get('/pos')->assertOk();
+        $this->actingAs($owner)->get('/transactions')->assertOk();
+    }
+
+    public function test_gudang_cannot_access_pos_routes(): void
+    {
+        $gudang = User::factory()->create([
+            'role' => 'gudang',
+            'mode_app' => 'lengkap',
+        ]);
+
+        $this->actingAs($gudang)->get('/pos')->assertForbidden();
+        $this->actingAs($gudang)->get('/transactions')->assertForbidden();
+        $this->actingAs($gudang)->post('/transactions', [])->assertForbidden();
+    }
+
+    public function test_kasir_only_sees_and_opens_their_own_transactions(): void
+    {
+        $kasir = User::factory()->create([
+            'role' => 'kasir',
+            'mode_app' => 'sederhana',
+            'name' => 'Kasir A',
+        ]);
+        $otherKasir = User::factory()->create([
+            'role' => 'kasir',
+            'mode_app' => 'sederhana',
+            'name' => 'Kasir B',
+        ]);
+
+        $ownTransaction = Transaction::create([
+            'kode_transaksi' => 'TRX-OWN-001',
+            'user_id' => $kasir->id,
+            'tanggal_transaksi' => now(),
+            'total_item' => 1,
+            'subtotal' => 10000,
+            'total_bayar' => 10000,
+            'nominal_bayar' => 10000,
+            'kembalian' => 0,
+            'status' => 'selesai',
+        ]);
+
+        $otherTransaction = Transaction::create([
+            'kode_transaksi' => 'TRX-OTHER-001',
+            'user_id' => $otherKasir->id,
+            'tanggal_transaksi' => now(),
+            'total_item' => 1,
+            'subtotal' => 15000,
+            'total_bayar' => 15000,
+            'nominal_bayar' => 15000,
+            'kembalian' => 0,
+            'status' => 'selesai',
+        ]);
+
+        $this->actingAs($kasir)
+            ->get('/transactions')
+            ->assertOk()
+            ->assertSee('TRX-OWN-001')
+            ->assertDontSee('TRX-OTHER-001');
+
+        $this->actingAs($kasir)
+            ->get(route('transactions.show', $ownTransaction))
+            ->assertOk();
+
+        $this->actingAs($kasir)
+            ->get(route('transactions.show', $otherTransaction))
+            ->assertForbidden();
+    }
+
+    private function createProduct(array $attributes = []): Product
+    {
+        $category = Category::create([
+            'nama_kategori' => fake()->unique()->word(),
+            'slug' => fake()->unique()->slug(),
+            'is_active' => true,
+        ]);
+
+        $supplier = Supplier::create([
+            'nama_supplier' => fake()->unique()->company(),
+            'nama_kontak' => fake()->name(),
+            'telepon' => fake()->numerify('08##########'),
+            'alamat' => fake()->address(),
+            'is_active' => true,
+        ]);
+
+        return Product::create($attributes + [
+            'category_id' => $category->id,
+            'supplier_id' => $supplier->id,
+            'kode_produk' => 'PRD-'.fake()->unique()->numerify('####'),
+            'nama_produk' => 'Produk '.fake()->unique()->word(),
+            'slug' => fake()->unique()->slug(),
+            'satuan' => 'pcs',
+            'harga_beli' => 10000,
+            'harga_jual' => 15000,
+            'stok' => 0,
+            'stok_minimum' => 2,
+            'is_active' => true,
+        ]);
+    }
+}

--- a/tests/Feature/SidebarRoleModeTest.php
+++ b/tests/Feature/SidebarRoleModeTest.php
@@ -69,7 +69,6 @@ class SidebarRoleModeTest extends TestCase
             ->assertSee('href="'.route('categories.index').'"', false)
             ->assertSee('href="'.route('suppliers.index').'"', false)
             ->assertSee('href="'.route('purchases.index').'"', false)
-            ->assertSee('href="'.route('stocks.notifications').'"', false)
             ->assertSee('href="'.route('forecasts.index').'"', false)
             ->assertDontSee('href="'.route('dashboard.index').'"', false)
             ->assertDontSee('href="'.route('users.index').'"', false)


### PR DESCRIPTION
Rapikan Transaksi Penjualan POS dan Update Stok Otomatis

  - POS sekarang benar-benar mendukung transaksi penjualan untuk kasir.
  - Owner tetap bisa akses POS sesuai mode toko.
  - Gudang tetap tidak bisa akses POS.
  - Validasi stok tidak cukup sudah ditegaskan lewat test khusus POS.
  - Setelah transaksi berhasil:
      - stok produk berkurang otomatis
      - transaction_items terisi
      - stock_movements mencatat stok keluar
  - Riwayat transaksi kasir dirapikan:
      - kasir hanya melihat transaksi miliknya sendiri
      - kasir tidak bisa membuka detail transaksi milik kasir lain
  - Ditambahkan feature test khusus POS:
      - buat transaksi berhasil
      - transaksi gagal jika stok tidak cukup
      - owner bisa akses POS
      - gudang tidak bisa akses POS
      - kasir hanya lihat transaksi sendiri
      - 
Implementasi Notifikasi Stok Menipis
  - Produk dianggap stok menipis jika stok <= stok_minimum.
  - Ditambahkan akses backend khusus notifikasi stok menipis:
      - owner bisa lihat
      - gudang mode lengkap bisa lihat
      - kasir tidak bisa akses
  - Route /stok/notifikasi sekarang menampilkan daftar produk stok menipis saja.
  - Icon lonceng di header diarahkan ke halaman notifikasi stok menipis.
  - Preview di dropdown lonceng tetap menampilkan produk kritis.
  - Menu Notifikasi Stok di sidebar gudang dihapus.
  - Halaman stok dipakai ulang untuk mode notifikasi dengan filter produk kritis.
  - Ditambahkan feature test untuk:
      - owner melihat hanya produk stok menipis
      - gudang mode lengkap bisa lihat notifikasi
      - kasir ditolak akses notifikasi