### PR TITLE
Prediksi Stok Moving Average & Akses Monitoring Owner Mode

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -13,7 +13,10 @@ class CategoryController extends Controller
     public function index(): View
     {
         $categories = Category::all();
-        return view('categories.index', compact('categories'));
+        return view('categories.index', [
+            'categories' => $categories,
+            'canManageCategories' => $this->canManageCategories(request()->user()?->role, request()->user()?->mode_app),
+        ]);
     }
 
     public function create(): View
@@ -37,7 +40,10 @@ class CategoryController extends Controller
 
     public function show(Category $category): View
     {
-        return view('categories.show', compact('category'));
+        return view('categories.show', [
+            'category' => $category,
+            'canManageCategories' => $this->canManageCategories(request()->user()?->role, request()->user()?->mode_app),
+        ]);
     }
 
     public function edit(Category $category): View
@@ -64,5 +70,14 @@ class CategoryController extends Controller
         $category->delete();
 
         return redirect()->route('categories.index')->with('success', 'Kategori berhasil dihapus.');
+    }
+
+    private function canManageCategories(?string $role, ?string $modeApp): bool
+    {
+        return match ($role) {
+            'owner' => $modeApp === 'sederhana',
+            'gudang' => $modeApp === 'lengkap',
+            default => false,
+        };
     }
 }

--- a/app/Http/Controllers/ForecastController.php
+++ b/app/Http/Controllers/ForecastController.php
@@ -2,45 +2,157 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Product;
 use App\Models\SalesForecast;
+use App\Services\SalesForecastService;
+use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 
 class ForecastController extends Controller
 {
-    public function index(): View
+    public function __construct(private readonly SalesForecastService $salesForecastService)
     {
-        return view('forecasts.index');
+    }
+
+    public function index(Request $request): View
+    {
+        $user = $request->user();
+        $isSimpleMode = $user?->mode_app === 'sederhana';
+        $canManageForecasts = $this->canManageForecasts($user?->role, $user?->mode_app);
+
+        $forecastRows = SalesForecast::query()
+            ->with('produk')
+            ->latest()
+            ->paginate(10);
+
+        $restockProducts = Product::query()
+            ->where('is_active', true)
+            ->orderByRaw('(stok_minimum - stok) DESC')
+            ->orderBy('nama_produk')
+            ->take(5)
+            ->get()
+            ->map(function (Product $product) use ($user) {
+                $preview = $this->salesForecastService->buildForecast(
+                    $product,
+                    Carbon::now(),
+                    $user?->role === 'gudang' ? 3 : 3,
+                );
+
+                return [
+                    'product' => $product,
+                    'forecast_qty' => $preview['prediksi_stok'],
+                    'restock_gap' => $preview['selisih_prediksi'],
+                ];
+            });
+
+        return view('forecasts.index', [
+            'isSimpleMode' => $isSimpleMode,
+            'forecastRows' => $forecastRows,
+            'restockProducts' => $restockProducts,
+            'transactionCount' => \App\Models\Transaction::query()->count(),
+            'canManageForecasts' => $canManageForecasts,
+        ]);
     }
 
     public function create(): View
     {
-        return view('forecasts.create');
+        return view('forecasts.create', [
+            'forecast' => null,
+            'forecastProducts' => Product::query()->where('is_active', true)->orderBy('nama_produk')->get(),
+            'canManageForecasts' => true,
+        ]);
     }
 
     public function store(Request $request): RedirectResponse
     {
-        return redirect()->route('forecasts.index');
+        $validated = $request->validate([
+            'product_id' => ['required', 'integer', Rule::exists('products', 'id')],
+            'periode_akhir' => ['required', 'date'],
+            'panjang_jendela' => ['required', 'integer', 'min:1', 'max:12'],
+            'catatan' => ['nullable', 'string', 'max:1000'],
+        ]);
+
+        $product = Product::query()->findOrFail($validated['product_id']);
+        $forecast = $this->salesForecastService->storeForecast(
+            $product,
+            (int) $request->user()->id,
+            Carbon::parse($validated['periode_akhir']),
+            (int) $validated['panjang_jendela'],
+            $validated['catatan'] ?? null,
+        );
+
+        return redirect()
+            ->route('forecasts.show', $forecast)
+            ->with('status', 'Prediksi stok berhasil dihitung dan disimpan.');
     }
 
     public function show(SalesForecast $forecast): View
     {
-        return view('forecasts.show', ['forecast' => $forecast]);
+        $forecast->load('produk');
+        $series = $this->salesForecastService->buildForecast(
+            $forecast->produk,
+            $forecast->periode_akhir->copy(),
+            (int) $forecast->panjang_jendela,
+        )['series'];
+
+        return view('forecasts.show', [
+            'forecast' => $forecast,
+            'series' => $series,
+            'canManageForecasts' => $this->canManageForecasts(request()->user()?->role, request()->user()?->mode_app),
+        ]);
     }
 
     public function edit(SalesForecast $forecast): View
     {
-        return view('forecasts.edit', ['forecast' => $forecast]);
+        return view('forecasts.edit', [
+            'forecast' => $forecast->load('produk'),
+            'forecastProducts' => Product::query()->where('is_active', true)->orderBy('nama_produk')->get(),
+            'canManageForecasts' => true,
+        ]);
     }
 
     public function update(Request $request, SalesForecast $forecast): RedirectResponse
     {
-        return redirect()->route('forecasts.index');
+        $validated = $request->validate([
+            'product_id' => ['required', 'integer', Rule::exists('products', 'id')],
+            'periode_akhir' => ['required', 'date'],
+            'panjang_jendela' => ['required', 'integer', 'min:1', 'max:12'],
+            'catatan' => ['nullable', 'string', 'max:1000'],
+        ]);
+
+        $product = Product::query()->findOrFail($validated['product_id']);
+        $forecast = $this->salesForecastService->updateForecast(
+            $forecast,
+            $product,
+            (int) $request->user()->id,
+            Carbon::parse($validated['periode_akhir']),
+            (int) $validated['panjang_jendela'],
+            $validated['catatan'] ?? null,
+        );
+
+        return redirect()
+            ->route('forecasts.show', $forecast)
+            ->with('status', 'Prediksi stok berhasil diperbarui.');
     }
 
     public function destroy(SalesForecast $forecast): RedirectResponse
     {
-        return redirect()->route('forecasts.index');
+        $forecast->delete();
+
+        return redirect()
+            ->route('forecasts.index')
+            ->with('status', 'Prediksi stok berhasil dihapus.');
+    }
+
+    private function canManageForecasts(?string $role, ?string $modeApp): bool
+    {
+        return match ($role) {
+            'owner' => $modeApp === 'sederhana',
+            'gudang' => $modeApp === 'lengkap',
+            default => false,
+        };
     }
 }

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -122,7 +122,7 @@ class ProductController extends Controller
     private function canManageProducts(?string $role, ?string $modeApp): bool
     {
         return match ($role) {
-            'owner' => in_array($modeApp, ['sederhana', 'lengkap'], true),
+            'owner' => $modeApp === 'sederhana',
             'gudang' => $modeApp === 'lengkap',
             default => false,
         };

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -2,12 +2,77 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Product;
+use App\Models\Purchase;
+use App\Models\Transaction;
+use Illuminate\Http\Request;
 use Illuminate\View\View;
 
 class ReportController extends Controller
 {
-    public function index(): View
+    public function index(Request $request): View
     {
-        return view('reports.index');
+        $user = $request->user();
+        $period = $request->string('period')->value() ?: '30_hari';
+        $days = match ($period) {
+            '7_hari' => 7,
+            '90_hari' => 90,
+            default => 30,
+        };
+
+        $startDate = now()->startOfDay()->subDays($days - 1);
+        $endDate = now()->endOfDay();
+
+        $salesQuery = Transaction::query()
+            ->with('kasir')
+            ->whereBetween('tanggal_transaksi', [$startDate, $endDate])
+            ->latest('tanggal_transaksi');
+
+        $purchasesQuery = Purchase::query()
+            ->with(['supplier', 'pengguna'])
+            ->whereBetween('tanggal_pembelian', [$startDate, $endDate])
+            ->latest('tanggal_pembelian');
+
+        $sales = $salesQuery->get();
+        $purchases = $purchasesQuery->get();
+        $stockProducts = Product::query()
+            ->with(['kategori', 'supplier'])
+            ->orderBy('nama_produk')
+            ->get();
+
+        $salesTotal = (float) $sales->sum('total_bayar');
+        $purchaseTotal = (float) $purchases->sum('total_bayar');
+        $stockValue = (float) $stockProducts->sum(fn (Product $product) => $product->stok * (float) $product->harga_beli);
+        $revenue = $salesTotal;
+        $capital = $purchaseTotal;
+        $grossProfit = $revenue - $capital;
+        $margin = $revenue > 0 ? ($grossProfit / $revenue) * 100 : 0;
+        $canViewSalesAndProfit = $user?->role === 'owner';
+        $canViewPurchases = $user?->role === 'owner' || ($user?->role === 'gudang' && $user->mode_app === 'lengkap');
+
+        return view('reports.index', [
+            'isSimpleMode' => $user?->mode_app === 'sederhana',
+            'isWarehouseViewer' => $user?->role === 'gudang',
+            'period' => $period,
+            'periodLabel' => match ($period) {
+                '7_hari' => '7 hari terakhir',
+                '90_hari' => '90 hari terakhir',
+                default => '30 hari terakhir',
+            },
+            'sales' => $sales,
+            'purchases' => $purchases,
+            'stockProducts' => $stockProducts,
+            'salesTotal' => $salesTotal,
+            'purchaseTotal' => $purchaseTotal,
+            'stockValue' => $stockValue,
+            'revenue' => $revenue,
+            'capital' => $capital,
+            'grossProfit' => $grossProfit,
+            'margin' => $margin,
+            'canViewSalesAndProfit' => $canViewSalesAndProfit,
+            'canViewPurchases' => $canViewPurchases,
+            'startDate' => $startDate,
+            'endDate' => $endDate,
+        ]);
     }
 }

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -100,7 +100,7 @@ class StockController extends Controller
     private function canManageStock(?string $role, ?string $modeApp): bool
     {
         return match ($role) {
-            'owner' => in_array($modeApp, ['sederhana', 'lengkap'], true),
+            'owner' => $modeApp === 'sederhana',
             'gudang' => $modeApp === 'lengkap',
             default => false,
         };

--- a/app/Http/Middleware/EnsureRoleModeAccess.php
+++ b/app/Http/Middleware/EnsureRoleModeAccess.php
@@ -27,10 +27,15 @@ class EnsureRoleModeAccess
 
         $bolehAkses = match ($access) {
             'owner' => $pengguna->role === 'owner',
+            'reports' => $this->canAccessReports($pengguna->role, $pengguna->mode_app),
+            'product-read' => $this->canReadProducts($pengguna->role, $pengguna->mode_app),
             'stock-read' => $this->canReadStock($pengguna->role, $pengguna->mode_app),
+            'stock-manage' => $this->canManageStock($pengguna->role, $pengguna->mode_app),
             'low-stock' => $this->canAccessLowStockNotifications($pengguna->role, $pengguna->mode_app),
-            'inventory' => $this->canAccessInventory($pengguna->role, $pengguna->mode_app),
-            'warehouse' => $this->canAccessWarehouse($pengguna->role, $pengguna->mode_app),
+            'inventory-read' => $this->canReadInventory($pengguna->role, $pengguna->mode_app),
+            'inventory-manage' => $this->canManageInventory($pengguna->role, $pengguna->mode_app),
+            'supplier-manage' => $this->canManageSuppliers($pengguna->role, $pengguna->mode_app),
+            'purchase-manage' => $this->canManagePurchases($pengguna->role, $pengguna->mode_app),
             'sales' => $this->canAccessSales($pengguna->role, $pengguna->mode_app),
             default => false,
         };
@@ -45,16 +50,53 @@ class EnsureRoleModeAccess
     private function canReadStock(string $role, ?string $modeApp): bool
     {
         return match ($role) {
+            'owner' => $modeApp === 'sederhana',
+            'kasir' => in_array($modeApp, ['sederhana', 'lengkap'], true),
+            'gudang' => $modeApp === 'lengkap',
+            default => false,
+        };
+    }
+
+    private function canReadProducts(string $role, ?string $modeApp): bool
+    {
+        return match ($role) {
             'owner', 'kasir' => in_array($modeApp, ['sederhana', 'lengkap'], true),
             'gudang' => $modeApp === 'lengkap',
             default => false,
         };
     }
 
-    private function canAccessInventory(string $role, ?string $modeApp): bool
+    private function canManageStock(string $role, ?string $modeApp): bool
+    {
+        return match ($role) {
+            'owner' => $modeApp === 'sederhana',
+            'gudang' => $modeApp === 'lengkap',
+            default => false,
+        };
+    }
+
+    private function canAccessReports(string $role, ?string $modeApp): bool
     {
         return match ($role) {
             'owner' => in_array($modeApp, ['sederhana', 'lengkap'], true),
+            'gudang' => $modeApp === 'lengkap',
+            default => false,
+        };
+    }
+
+    private function canReadInventory(string $role, ?string $modeApp): bool
+    {
+        return match ($role) {
+            'owner' => in_array($modeApp, ['sederhana', 'lengkap'], true),
+            'gudang' => $modeApp === 'lengkap',
+            default => false,
+        };
+    }
+
+    private function canManageInventory(string $role, ?string $modeApp): bool
+    {
+        return match ($role) {
+            'owner' => $modeApp === 'sederhana',
             'gudang' => $modeApp === 'lengkap',
             default => false,
         };
@@ -69,10 +111,19 @@ class EnsureRoleModeAccess
         };
     }
 
-    private function canAccessWarehouse(string $role, ?string $modeApp): bool
+    private function canManageSuppliers(string $role, ?string $modeApp): bool
     {
         return match ($role) {
-            'owner', 'gudang' => $modeApp === 'lengkap',
+            'owner' => $modeApp === 'sederhana',
+            'gudang' => $modeApp === 'lengkap',
+            default => false,
+        };
+    }
+
+    private function canManagePurchases(string $role, ?string $modeApp): bool
+    {
+        return match ($role) {
+            'gudang' => $modeApp === 'lengkap',
             default => false,
         };
     }

--- a/app/Services/SalesForecastService.php
+++ b/app/Services/SalesForecastService.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Product;
+use App\Models\SalesForecast;
+use App\Models\TransactionItem;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class SalesForecastService
+{
+    public function buildForecast(Product $product, Carbon $periodEnd, int $windowMonths): array
+    {
+        $windowMonths = max(1, min($windowMonths, 12));
+        $periodEnd = $periodEnd->copy()->endOfMonth();
+        $periodStart = $periodEnd->copy()->subMonths($windowMonths - 1)->startOfMonth();
+        $months = collect(range(0, $windowMonths - 1))
+            ->map(fn (int $offset) => $periodStart->copy()->addMonths($offset)->startOfMonth());
+
+        $transactionItems = TransactionItem::query()
+            ->select(['transaction_items.qty', 'transactions.tanggal_transaksi'])
+            ->join('transactions', 'transactions.id', '=', 'transaction_items.transaction_id')
+            ->where('transaction_items.product_id', $product->id)
+            ->where('transactions.status', 'selesai')
+            ->whereBetween('transactions.tanggal_transaksi', [$periodStart, $periodEnd])
+            ->get();
+
+        $monthlySales = $transactionItems
+            ->groupBy(fn (TransactionItem $item) => Carbon::parse($item->getAttribute('tanggal_transaksi'))->format('Y-m-01'))
+            ->map(fn (Collection $items): int => (int) $items->sum('qty'));
+
+        $series = $months->map(function (Carbon $month) use ($monthlySales): int {
+            return (int) ($monthlySales[$month->format('Y-m-01')] ?? 0);
+        });
+
+        $divisor = max($series->filter(fn (int $qty) => $qty > 0)->count(), 1);
+        $movingAverage = round($series->sum() / $divisor, 2);
+        $forecastQty = (int) ceil($movingAverage);
+        $restockGap = max($forecastQty - (int) $product->stok, 0);
+
+        return [
+            'periode_awal' => $periodStart->toDateString(),
+            'periode_akhir' => $periodEnd->toDateString(),
+            'panjang_jendela' => $windowMonths,
+            'nilai_moving_average' => $movingAverage,
+            'prediksi_stok' => $forecastQty,
+            'stok_aktual' => (int) $product->stok,
+            'selisih_prediksi' => $restockGap,
+            'catatan_default' => $restockGap > 0
+                ? 'Rekomendasi restock minimal '.$restockGap.' '.$product->satuan.' untuk menjaga stok periode berikutnya.'
+                : 'Stok saat ini masih cukup untuk menutup prediksi penjualan periode berikutnya.',
+            'series' => $this->mapSeries($months, $series),
+        ];
+    }
+
+    public function storeForecast(Product $product, int $userId, Carbon $periodEnd, int $windowMonths, ?string $note = null): SalesForecast
+    {
+        $forecast = $this->buildForecast($product, $periodEnd, $windowMonths);
+
+        return SalesForecast::create([
+            'product_id' => $product->id,
+            'user_id' => $userId,
+            'periode_awal' => $forecast['periode_awal'],
+            'periode_akhir' => $forecast['periode_akhir'],
+            'panjang_jendela' => $forecast['panjang_jendela'],
+            'nilai_moving_average' => $forecast['nilai_moving_average'],
+            'prediksi_stok' => $forecast['prediksi_stok'],
+            'stok_aktual' => $forecast['stok_aktual'],
+            'selisih_prediksi' => $forecast['selisih_prediksi'],
+            'catatan' => filled($note) ? $note : $forecast['catatan_default'],
+        ]);
+    }
+
+    public function updateForecast(SalesForecast $forecast, Product $product, int $userId, Carbon $periodEnd, int $windowMonths, ?string $note = null): SalesForecast
+    {
+        $payload = $this->buildForecast($product, $periodEnd, $windowMonths);
+
+        $forecast->update([
+            'product_id' => $product->id,
+            'user_id' => $userId,
+            'periode_awal' => $payload['periode_awal'],
+            'periode_akhir' => $payload['periode_akhir'],
+            'panjang_jendela' => $payload['panjang_jendela'],
+            'nilai_moving_average' => $payload['nilai_moving_average'],
+            'prediksi_stok' => $payload['prediksi_stok'],
+            'stok_aktual' => $payload['stok_aktual'],
+            'selisih_prediksi' => $payload['selisih_prediksi'],
+            'catatan' => filled($note) ? $note : $payload['catatan_default'],
+        ]);
+
+        return $forecast->refresh();
+    }
+
+    private function mapSeries(Collection $months, Collection $series): Collection
+    {
+        return $months->values()->map(function (Carbon $month, int $index) use ($series): array {
+            return [
+                'label' => $month->translatedFormat('M Y'),
+                'qty' => (int) $series[$index],
+            ];
+        });
+    }
+}

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -8,12 +8,14 @@
 @section('page_title', 'Kategori')
 @section('page_subtitle', $isSimpleMode
     ? 'Kelola daftar kategori produk dan proses tambah/edit/hapus kategori untuk owner mode sederhana.'
-    : 'Kelola klasifikasi produk dan CRUD kategori untuk owner mode lengkap.')
+    : 'Pantau klasifikasi produk untuk monitoring owner mode lengkap tanpa perubahan data operasional.')
 
 @section('page_actions')
-    <a href="{{ route('categories.create') }}" class="inline-flex h-11 items-center rounded-lg bg-[#003441] px-4 text-sm font-semibold text-white transition hover:bg-[#0f4c5c]">
-        Tambah Kategori
-    </a>
+    @if ($canManageCategories)
+        <a href="{{ route('categories.create') }}" class="inline-flex h-11 items-center rounded-lg bg-[#003441] px-4 text-sm font-semibold text-white transition hover:bg-[#0f4c5c]">
+            Tambah Kategori
+        </a>
+    @endif
 @endsection
 
 @section('content')
@@ -66,16 +68,18 @@
                                         <a href="{{ route('categories.show', $category) }}" class="inline-flex h-9 items-center rounded-lg border border-slate-200 px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50">
                                             Detail
                                         </a>
-                                        <a href="{{ route('categories.edit', $category) }}" class="inline-flex h-9 items-center rounded-lg border border-[#c0c8cb] px-3 text-sm font-medium text-[#003441] transition hover:bg-[#f3f4f5]">
-                                            Edit
-                                        </a>
-                                        <form action="{{ route('categories.destroy', $category) }}" method="POST">
-                                            @csrf
-                                            @method('DELETE')
-                                            <button type="submit" class="inline-flex h-9 items-center rounded-lg border border-red-100 px-3 text-sm font-medium text-red-600 transition hover:bg-red-50">
-                                                Hapus
-                                            </button>
-                                        </form>
+                                        @if ($canManageCategories)
+                                            <a href="{{ route('categories.edit', $category) }}" class="inline-flex h-9 items-center rounded-lg border border-[#c0c8cb] px-3 text-sm font-medium text-[#003441] transition hover:bg-[#f3f4f5]">
+                                                Edit
+                                            </a>
+                                            <form action="{{ route('categories.destroy', $category) }}" method="POST">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="inline-flex h-9 items-center rounded-lg border border-red-100 px-3 text-sm font-medium text-red-600 transition hover:bg-red-50">
+                                                    Hapus
+                                                </button>
+                                            </form>
+                                        @endif
                                     </div>
                                 </td>
                             </tr>

--- a/resources/views/categories/show.blade.php
+++ b/resources/views/categories/show.blade.php
@@ -11,9 +11,11 @@
     : 'Lihat detail kategori untuk membantu klasifikasi produk pada mode lengkap tetap terkontrol.')
 
 @section('page_actions')
-    <a href="{{ route('categories.edit', $category) }}" class="inline-flex h-11 items-center rounded-lg border border-[#c0c8cb] bg-white px-4 text-sm font-semibold text-[#003441] transition hover:bg-[#f3f4f5]">
-        Edit Kategori
-    </a>
+    @if ($canManageCategories)
+        <a href="{{ route('categories.edit', $category) }}" class="inline-flex h-11 items-center rounded-lg border border-[#c0c8cb] bg-white px-4 text-sm font-semibold text-[#003441] transition hover:bg-[#f3f4f5]">
+            Edit Kategori
+        </a>
+    @endif
 @endsection
 
 @section('content')

--- a/resources/views/forecasts/_form.blade.php
+++ b/resources/views/forecasts/_form.blade.php
@@ -1,7 +1,3 @@
-@php
-    $forecastProducts = \App\Models\Product::query()->orderBy('nama_produk')->get();
-@endphp
-
 <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
     <div class="space-y-2 md:col-span-2">
         <label for="product_id" class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Produk</label>
@@ -17,17 +13,9 @@
                 </option>
             @endforeach
         </select>
-    </div>
-
-    <div class="space-y-2">
-        <label for="periode_awal" class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Periode Awal</label>
-        <input
-            id="periode_awal"
-            name="periode_awal"
-            type="date"
-            value="{{ old('periode_awal', optional($forecast->periode_awal ?? null)->format('Y-m-d')) }}"
-            class="h-11 w-full rounded-lg border border-[#c0c8cb] bg-white px-4 text-sm text-slate-700 outline-none transition focus:border-[#003441] focus:ring-2 focus:ring-[#003441]/10"
-        />
+        @error('product_id')
+            <p class="text-sm text-red-600">{{ $message }}</p>
+        @enderror
     </div>
 
     <div class="space-y-2">
@@ -36,9 +24,12 @@
             id="periode_akhir"
             name="periode_akhir"
             type="date"
-            value="{{ old('periode_akhir', optional($forecast->periode_akhir ?? null)->format('Y-m-d')) }}"
+            value="{{ old('periode_akhir', optional($forecast->periode_akhir ?? now())->format('Y-m-d')) }}"
             class="h-11 w-full rounded-lg border border-[#c0c8cb] bg-white px-4 text-sm text-slate-700 outline-none transition focus:border-[#003441] focus:ring-2 focus:ring-[#003441]/10"
         />
+        @error('periode_akhir')
+            <p class="text-sm text-red-600">{{ $message }}</p>
+        @enderror
     </div>
 
     <div class="space-y-2">
@@ -48,50 +39,15 @@
             name="panjang_jendela"
             type="number"
             min="1"
-            value="{{ old('panjang_jendela', $forecast->panjang_jendela ?? 7) }}"
-            placeholder="Contoh: 7"
+            max="12"
+            value="{{ old('panjang_jendela', $forecast->panjang_jendela ?? 3) }}"
+            placeholder="Contoh: 3"
             class="h-11 w-full rounded-lg border border-[#c0c8cb] bg-white px-4 text-sm text-slate-700 outline-none transition focus:border-[#003441] focus:ring-2 focus:ring-[#003441]/10"
         />
-    </div>
-
-    <div class="space-y-2">
-        <label for="prediksi_stok" class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Prediksi Stok</label>
-        <input
-            id="prediksi_stok"
-            name="prediksi_stok"
-            type="number"
-            min="0"
-            value="{{ old('prediksi_stok', $forecast->prediksi_stok ?? '') }}"
-            placeholder="Estimasi stok periode berikutnya"
-            class="h-11 w-full rounded-lg border border-[#c0c8cb] bg-white px-4 text-sm text-slate-700 outline-none transition focus:border-[#003441] focus:ring-2 focus:ring-[#003441]/10"
-        />
-    </div>
-
-    <div class="space-y-2">
-        <label for="stok_aktual" class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Stok Aktual</label>
-        <input
-            id="stok_aktual"
-            name="stok_aktual"
-            type="number"
-            min="0"
-            value="{{ old('stok_aktual', $forecast->stok_aktual ?? '') }}"
-            placeholder="Stok saat ini"
-            class="h-11 w-full rounded-lg border border-[#c0c8cb] bg-white px-4 text-sm text-slate-700 outline-none transition focus:border-[#003441] focus:ring-2 focus:ring-[#003441]/10"
-        />
-    </div>
-
-    <div class="space-y-2">
-        <label for="nilai_moving_average" class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Nilai Moving Average</label>
-        <input
-            id="nilai_moving_average"
-            name="nilai_moving_average"
-            type="number"
-            step="0.01"
-            min="0"
-            value="{{ old('nilai_moving_average', $forecast->nilai_moving_average ?? '') }}"
-            placeholder="Contoh: 12.50"
-            class="h-11 w-full rounded-lg border border-[#c0c8cb] bg-white px-4 text-sm text-slate-700 outline-none transition focus:border-[#003441] focus:ring-2 focus:ring-[#003441]/10"
-        />
+        <p class="text-xs text-slate-500">Gunakan jumlah bulan terakhir yang ingin dihitung. Rekomendasi awal: 3 bulan.</p>
+        @error('panjang_jendela')
+            <p class="text-sm text-red-600">{{ $message }}</p>
+        @enderror
     </div>
 
     <div class="space-y-2 md:col-span-2">
@@ -103,5 +59,8 @@
             placeholder="Tulis insight singkat, rekomendasi restock, atau catatan tren penjualan."
             class="w-full rounded-lg border border-[#c0c8cb] bg-white px-4 py-3 text-sm text-slate-700 outline-none transition focus:border-[#003441] focus:ring-2 focus:ring-[#003441]/10"
         >{{ old('catatan', $forecast->catatan ?? '') }}</textarea>
+        @error('catatan')
+            <p class="text-sm text-red-600">{{ $message }}</p>
+        @enderror
     </div>
 </div>

--- a/resources/views/forecasts/create.blade.php
+++ b/resources/views/forecasts/create.blade.php
@@ -16,11 +16,11 @@
             <div class="mt-5 space-y-4">
                 <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
                     <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Periode Analisis</p>
-                    <p class="mt-2 text-sm leading-6 text-slate-600">Pilih periode yang mewakili pola penjualan produk agar hasil prediksi lebih relevan.</p>
+                    <p class="mt-2 text-sm leading-6 text-slate-600">Sistem akan menghitung rata-rata penjualan dari beberapa bulan terakhir dengan metode Simple Moving Average.</p>
                 </div>
                 <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
                     <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Rekomendasi Restock</p>
-                    <p class="mt-2 text-sm leading-6 text-slate-600">Gunakan kolom catatan untuk menulis kebutuhan restock atau catatan tren produk.</p>
+                    <p class="mt-2 text-sm leading-6 text-slate-600">Setelah disimpan, sistem akan mengisi prediksi stok, stok aktual, moving average, dan gap restock secara otomatis.</p>
                 </div>
             </div>
         </section>

--- a/resources/views/forecasts/edit.blade.php
+++ b/resources/views/forecasts/edit.blade.php
@@ -9,6 +9,12 @@
     ? 'Perbarui prediksi stok sederhana agar rekomendasi owner tetap akurat untuk operasional harian.'
     : 'Perbarui parameter prediksi stok untuk menyesuaikan tren penjualan dan kebutuhan restock.')
 
+@section('page_actions')
+    <a href="{{ route('forecasts.show', $forecast) }}" class="inline-flex h-11 items-center rounded-lg border border-[#c0c8cb] bg-white px-4 text-sm font-semibold text-[#003441] transition hover:bg-[#f3f4f5]">
+        Lihat Detail
+    </a>
+@endsection
+
 @section('content')
     <div class="grid grid-cols-1 gap-6 xl:grid-cols-[0.72fr_1.28fr]">
         <section class="rounded-2xl border border-[#c0c8cb] bg-white p-6 shadow-sm">
@@ -32,8 +38,8 @@
                 @include('forecasts._form', ['forecast' => $forecast])
 
                 <div class="flex flex-col gap-3 border-t border-slate-200 pt-6 sm:flex-row sm:items-center sm:justify-end">
-                    <a href="{{ route('forecasts.show', $forecast) }}" class="inline-flex h-11 items-center justify-center rounded-lg border border-[#c0c8cb] px-4 text-sm font-semibold text-slate-700 transition hover:bg-[#f3f4f5]">
-                        Lihat Detail
+                    <a href="{{ route('forecasts.index') }}" class="inline-flex h-11 items-center justify-center rounded-lg border border-[#c0c8cb] px-4 text-sm font-semibold text-slate-700 transition hover:bg-[#f3f4f5]">
+                        Kembali
                     </a>
                     <button type="submit" class="inline-flex h-11 items-center justify-center rounded-lg bg-[#003441] px-4 text-sm font-semibold text-white transition hover:bg-[#0f4c5c]">
                         Update Prediksi

--- a/resources/views/forecasts/index.blade.php
+++ b/resources/views/forecasts/index.blade.php
@@ -1,21 +1,16 @@
 @extends('layouts.app')
 
-@php
-    $isSimpleMode = auth()->user()?->mode_app === 'sederhana';
-    $forecastRows = \App\Models\SalesForecast::query()->with('produk')->latest()->take(8)->get();
-    $trendingProducts = \App\Models\Product::query()->orderByDesc('stok')->take(5)->get();
-    $transactionCount = \App\Models\Transaction::query()->count();
-@endphp
-
 @section('page_title', 'Prediksi Stok')
 @section('page_subtitle', $isSimpleMode
     ? 'Prediksi kebutuhan stok sederhana, rekomendasi restock, dan tren penjualan barang.'
     : 'Prediksi stok per produk, kebutuhan restock, dan analisis tren penjualan untuk owner mode lengkap.')
 
 @section('page_actions')
-    <a href="{{ route('forecasts.create') }}" class="inline-flex h-11 items-center rounded-lg bg-[#003441] px-4 text-sm font-semibold text-white transition hover:bg-[#0f4c5c]">
-        Tambah Prediksi
-    </a>
+    @if ($canManageForecasts)
+        <a href="{{ route('forecasts.create') }}" class="inline-flex h-11 items-center rounded-lg bg-[#003441] px-4 text-sm font-semibold text-white transition hover:bg-[#0f4c5c]">
+            Tambah Prediksi
+        </a>
+    @endif
 @endsection
 
 @section('content')
@@ -31,11 +26,11 @@
                 <div class="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-3">
                     <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
                         <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Data Prediksi</p>
-                        <p class="mt-2 text-3xl font-bold text-slate-900">{{ $forecastRows->count() }}</p>
+                        <p class="mt-2 text-3xl font-bold text-slate-900">{{ $forecastRows->total() }}</p>
                     </div>
                     <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
                         <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Produk Terpantau</p>
-                        <p class="mt-2 text-3xl font-bold text-slate-900">{{ $trendingProducts->count() }}</p>
+                        <p class="mt-2 text-3xl font-bold text-slate-900">{{ $restockProducts->count() }}</p>
                     </div>
                     <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
                         <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Riwayat Penjualan</p>
@@ -47,21 +42,18 @@
             <article class="rounded-2xl border border-[#c0c8cb] bg-white p-6 shadow-sm">
                 <h2 class="text-lg font-semibold text-slate-900">{{ $isSimpleMode ? 'Rekomendasi Restock' : 'Kebutuhan Restock' }}</h2>
                 <div class="mt-4 space-y-3">
-                    @forelse ($trendingProducts as $product)
-                        @php
-                            $restockGap = max(($product->stok_minimum ?? 0) - ($product->stok ?? 0), 0);
-                        @endphp
+                    @forelse ($restockProducts as $restockItem)
                         <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
                             <div class="flex items-start justify-between gap-4">
                                 <div>
-                                    <p class="font-semibold text-slate-900">{{ $product->nama_produk }}</p>
-                                    <p class="mt-1 text-xs text-slate-500">{{ $product->kode_produk }}</p>
+                                    <p class="font-semibold text-slate-900">{{ $restockItem['product']->nama_produk }}</p>
+                                    <p class="mt-1 text-xs text-slate-500">{{ $restockItem['product']->kode_produk }}</p>
                                 </div>
-                                <span class="rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-[0.16em] {{ $restockGap > 0 ? 'bg-red-50 text-red-600' : 'bg-[#d0e1fb]/40 text-[#0f4c5c]' }}">
-                                    {{ $restockGap > 0 ? 'Perlu Restock' : 'Aman' }}
+                                <span class="rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-[0.16em] {{ $restockItem['restock_gap'] > 0 ? 'bg-red-50 text-red-600' : 'bg-[#d0e1fb]/40 text-[#0f4c5c]' }}">
+                                    {{ $restockItem['restock_gap'] > 0 ? 'Perlu Restock' : 'Aman' }}
                                 </span>
                             </div>
-                            <p class="mt-3 text-sm text-slate-600">Stok saat ini {{ $product->stok }} {{ $product->satuan }}. Batas minimum {{ $product->stok_minimum }} {{ $product->satuan }}.</p>
+                            <p class="mt-3 text-sm text-slate-600">Prediksi kebutuhan {{ $restockItem['forecast_qty'] }} {{ $restockItem['product']->satuan }}. Stok saat ini {{ $restockItem['product']->stok }} {{ $restockItem['product']->satuan }}.</p>
                         </div>
                     @empty
                         <p class="text-sm text-slate-500">Belum ada produk untuk dianalisis.</p>
@@ -91,7 +83,7 @@
                         @forelse ($forecastRows as $forecast)
                             <tr class="transition hover:bg-slate-50">
                                 <td class="px-6 py-4">
-                                    <p class="font-semibold text-slate-900">{{ $forecast->produk?->nama_produk ?? 'Produk tidak ditemukan' }}</p>
+                                    <a href="{{ route('forecasts.show', $forecast) }}" class="font-semibold text-slate-900 hover:text-[#0f4c5c]">{{ $forecast->produk?->nama_produk ?? 'Produk tidak ditemukan' }}</a>
                                     <p class="mt-1 text-xs text-slate-500">{{ $forecast->produk?->kode_produk ?? '-' }}</p>
                                 </td>
                                 <td class="px-6 py-4 text-slate-600">
@@ -113,6 +105,9 @@
                         @endforelse
                     </tbody>
                 </table>
+            </div>
+            <div class="border-t border-slate-200 px-6 py-4">
+                {{ $forecastRows->links() }}
             </div>
         </section>
     </div>

--- a/resources/views/forecasts/show.blade.php
+++ b/resources/views/forecasts/show.blade.php
@@ -10,9 +10,20 @@
     : 'Lihat detail prediksi stok untuk mengevaluasi hasil analisis dan kebutuhan restock produk.')
 
 @section('page_actions')
-    <a href="{{ route('forecasts.edit', $forecast) }}" class="inline-flex h-11 items-center rounded-lg border border-[#c0c8cb] bg-white px-4 text-sm font-semibold text-[#003441] transition hover:bg-[#f3f4f5]">
-        Edit Prediksi
-    </a>
+    @if ($canManageForecasts)
+        <div class="flex items-center gap-3">
+            <a href="{{ route('forecasts.edit', $forecast) }}" class="inline-flex h-11 items-center rounded-lg border border-[#c0c8cb] bg-white px-4 text-sm font-semibold text-[#003441] transition hover:bg-[#f3f4f5]">
+                Edit Prediksi
+            </a>
+            <form action="{{ route('forecasts.destroy', $forecast) }}" method="POST" onsubmit="return confirm('Hapus prediksi stok ini?')">
+                @csrf
+                @method('DELETE')
+                <button type="submit" class="inline-flex h-11 items-center rounded-lg border border-red-200 bg-white px-4 text-sm font-semibold text-red-600 transition hover:bg-red-50">
+                    Hapus
+                </button>
+            </form>
+        </div>
+    @endif
 @endsection
 
 @section('content')
@@ -22,11 +33,11 @@
             <div class="mt-5 space-y-4">
                 <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
                     <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Prediksi Stok</p>
-                    <p class="mt-2 text-4xl font-bold tracking-tight text-[#003441]">{{ $forecast->prediksi_stok ?? '-' }}</p>
+                    <p class="mt-2 text-4xl font-bold tracking-tight text-[#003441]">{{ $forecast->prediksi_stok ?? '-' }} {{ $forecast->produk?->satuan ?? '' }}</p>
                 </div>
                 <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
                     <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Stok Aktual</p>
-                    <p class="mt-2 text-4xl font-bold tracking-tight text-slate-900">{{ $forecast->stok_aktual ?? '-' }}</p>
+                    <p class="mt-2 text-4xl font-bold tracking-tight text-slate-900">{{ $forecast->stok_aktual ?? '-' }} {{ $forecast->produk?->satuan ?? '' }}</p>
                 </div>
             </div>
         </section>
@@ -48,15 +59,27 @@
                 </div>
                 <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
                     <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Moving Average</p>
-                    <p class="mt-2 text-sm font-semibold text-slate-900">{{ $forecast->nilai_moving_average ?? '-' }}</p>
+                    <p class="mt-2 text-sm font-semibold text-slate-900">{{ number_format((float) $forecast->nilai_moving_average, 2, ',', '.') }}</p>
                 </div>
                 <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
                     <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Panjang Jendela</p>
-                    <p class="mt-2 text-sm font-semibold text-slate-900">{{ $forecast->panjang_jendela ?? '-' }}</p>
+                    <p class="mt-2 text-sm font-semibold text-slate-900">{{ $forecast->panjang_jendela ?? '-' }} bulan</p>
                 </div>
                 <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4 md:col-span-2">
-                    <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Selisih Prediksi</p>
-                    <p class="mt-2 text-sm font-semibold text-slate-900">{{ $forecast->selisih_prediksi ?? '-' }}</p>
+                    <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Rekomendasi Restock</p>
+                    <p class="mt-2 text-sm font-semibold text-slate-900">{{ $forecast->selisih_prediksi ?? '-' }} {{ $forecast->produk?->satuan ?? '' }}</p>
+                </div>
+            </div>
+
+            <div class="border-t border-slate-200 px-6 py-4">
+                <h3 class="text-sm font-semibold text-slate-900">Riwayat Penjualan per Bulan</h3>
+                <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
+                    @foreach ($series as $point)
+                        <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
+                            <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">{{ $point['label'] }}</p>
+                            <p class="mt-2 text-xl font-bold text-slate-900">{{ $point['qty'] }} {{ $forecast->produk?->satuan ?? '' }}</p>
+                        </div>
+                    @endforeach
                 </div>
             </div>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -38,7 +38,6 @@
                     ['label' => 'Dashboard', 'route' => 'dashboard.index', 'icon' => 'dashboard'],
                     ['label' => 'Produk', 'route' => 'products.index', 'icon' => 'products'],
                     ['label' => 'Kategori', 'route' => 'categories.index', 'icon' => 'categories'],
-                    ['label' => 'Stok', 'route' => 'stocks.role-home', 'icon' => 'stocks'],
                     ['label' => 'Laporan', 'route' => 'reports.index', 'icon' => 'reports'],
                     ['label' => 'Prediksi Stok', 'route' => 'forecasts.index', 'icon' => 'forecast'],
                     ['label' => 'Manajemen User', 'route' => 'users.index', 'icon' => 'users'],

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -8,7 +8,9 @@
 @section('page_title', 'Produk')
 @section('page_subtitle', $isSimpleMode
     ? 'Kelola daftar produk, tambah/edit/hapus produk, harga beli dan jual, serta stok per produk untuk owner mode sederhana.'
-    : 'Kelola daftar produk, detail stok, harga jual dan beli, serta supplier terkait untuk owner mode lengkap.')
+    : ($canManageProducts
+        ? 'Kelola daftar produk, detail stok, harga jual dan beli, serta supplier terkait untuk operasional gudang.'
+        : 'Pantau daftar produk, harga, stok, dan supplier terkait untuk monitoring owner mode lengkap.'))
 
 @section('page_actions')
     @if ($canManageProducts)
@@ -39,7 +41,7 @@
             <div class="flex items-center justify-between border-b border-[#c0c8cb] px-6 py-4">
                 <div>
                     <h2 class="text-lg font-semibold text-slate-900">Daftar Produk</h2>
-                    <p class="mt-1 text-sm text-slate-500">{{ $isSimpleMode ? 'Tampilkan daftar produk, harga jual beli, stok per produk, dan aksi pengelolaan sederhana.' : 'Tampilkan harga, stok minimum, supplier terkait, dan status produk aktif.' }}</p>
+                    <p class="mt-1 text-sm text-slate-500">{{ $isSimpleMode ? 'Tampilkan daftar produk, harga jual beli, stok per produk, dan aksi pengelolaan sederhana.' : ($canManageProducts ? 'Tampilkan harga, stok minimum, supplier terkait, dan status produk aktif.' : 'Tampilkan data produk aktif untuk evaluasi owner tanpa aksi perubahan data.') }}</p>
                 </div>
                 <span class="rounded-full bg-[#d0e1fb]/35 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.16em] text-[#0f4c5c]">
                     {{ $products->total() }} Produk

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -1,24 +1,11 @@
 @extends('layouts.app')
 
-@php
-    $isSimpleMode = auth()->user()?->mode_app === 'sederhana';
-    $period = request('period', '30_hari');
-    $periodLabel = match ($period) {
-        '7_hari' => '7 hari terakhir',
-        '90_hari' => '90 hari terakhir',
-        default => '30 hari terakhir',
-    };
-
-    $salesTotal = (float) \App\Models\Transaction::query()->sum('total_bayar');
-    $purchaseTotal = (float) \App\Models\Purchase::query()->sum('total_bayar');
-    $stockValue = (float) \App\Models\Product::query()->selectRaw('SUM(stok * harga_beli) as total')->value('total');
-    $avgMargin = $salesTotal > 0 ? max($salesTotal - $purchaseTotal, 0) / $salesTotal * 100 : 0;
-@endphp
-
 @section('page_title', 'Laporan')
-@section('page_subtitle', $isSimpleMode
-    ? 'Pantau laporan penjualan, ringkasan stok, barang terlaris, dan filter tanggal untuk owner mode sederhana.'
-    : 'Pantau laporan penjualan, pembelian, stok, filter periode, dan ringkasan performa bisnis owner mode lengkap.')
+@section('page_subtitle', $isWarehouseViewer
+    ? 'Pantau laporan stok dan pembelian untuk kebutuhan operasional gudang.'
+    : ($isSimpleMode
+        ? 'Pantau laporan penjualan, ringkasan stok, barang terlaris, dan filter tanggal untuk owner mode sederhana.'
+        : 'Pantau laporan penjualan, pembelian, stok, filter periode, dan ringkasan performa bisnis owner mode lengkap.'))
 
 @section('page_actions')
     <form method="GET" class="flex items-center gap-3">
@@ -36,64 +23,93 @@
 @section('content')
     <div class="space-y-6">
         <section class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
-            <article class="rounded-2xl border border-[#c0c8cb] bg-white p-6 shadow-sm">
-                <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Laporan Penjualan</p>
-                <h2 class="mt-3 text-3xl font-bold tracking-tight text-slate-900">Rp{{ number_format($salesTotal, 0, ',', '.') }}</h2>
-                <p class="mt-2 text-sm text-slate-500">Total penjualan untuk {{ $periodLabel }}.</p>
-            </article>
-            @if ($isSimpleMode)
+            @if ($canViewSalesAndProfit)
                 <article class="rounded-2xl border border-[#c0c8cb] bg-white p-6 shadow-sm">
-                    <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Ringkasan Stok</p>
-                    <h2 class="mt-3 text-3xl font-bold tracking-tight text-slate-900">Rp{{ number_format($stockValue, 0, ',', '.') }}</h2>
-                    <p class="mt-2 text-sm text-slate-500">Estimasi nilai stok aktif untuk pemantauan owner sederhana.</p>
-                </article>
-            @else
-                <article class="rounded-2xl border border-[#c0c8cb] bg-white p-6 shadow-sm">
-                    <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Laporan Pembelian</p>
-                    <h2 class="mt-3 text-3xl font-bold tracking-tight text-slate-900">Rp{{ number_format($purchaseTotal, 0, ',', '.') }}</h2>
-                    <p class="mt-2 text-sm text-slate-500">Total pembelian supplier pada periode terpilih.</p>
+                    <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Laporan Penjualan</p>
+                    <h2 class="mt-3 text-3xl font-bold tracking-tight text-slate-900">Rp{{ number_format($salesTotal, 0, ',', '.') }}</h2>
+                    <p class="mt-2 text-sm text-slate-500">Total penjualan untuk {{ $periodLabel }}.</p>
                 </article>
             @endif
             <article class="rounded-2xl border border-[#c0c8cb] bg-white p-6 shadow-sm">
-                <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">{{ $isSimpleMode ? 'Barang Terlaris' : 'Laporan Stok' }}</p>
-                <h2 class="mt-3 text-3xl font-bold tracking-tight text-slate-900">Rp{{ number_format($stockValue, 0, ',', '.') }}</h2>
-                <p class="mt-2 text-sm text-slate-500">{{ $isSimpleMode ? 'Gunakan data ini untuk menilai kebutuhan restock barang paling cepat bergerak.' : 'Estimasi nilai modal stok aktif saat ini.' }}</p>
+                <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">{{ $canViewPurchases ? 'Laporan Pembelian' : 'Ringkasan Stok' }}</p>
+                <h2 class="mt-3 text-3xl font-bold tracking-tight text-slate-900">Rp{{ number_format($canViewPurchases ? $purchaseTotal : $stockValue, 0, ',', '.') }}</h2>
+                <p class="mt-2 text-sm text-slate-500">{{ $canViewPurchases ? 'Total pembelian supplier pada periode terpilih.' : 'Estimasi nilai stok aktif untuk pemantauan owner sederhana.' }}</p>
             </article>
             <article class="rounded-2xl border border-[#c0c8cb] bg-white p-6 shadow-sm">
-                <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">{{ $isSimpleMode ? 'Filter Tanggal' : 'Performa Bisnis' }}</p>
-                <h2 class="mt-3 text-3xl font-bold tracking-tight text-slate-900">{{ number_format($avgMargin, 1, ',', '.') }}%</h2>
-                <p class="mt-2 text-sm text-slate-500">{{ $isSimpleMode ? 'Pantau perubahan performa sederhana berdasarkan periode yang dipilih.' : 'Margin kasar antara penjualan dan pembelian.' }}</p>
+                <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Laporan Stok</p>
+                <h2 class="mt-3 text-3xl font-bold tracking-tight text-slate-900">Rp{{ number_format($stockValue, 0, ',', '.') }}</h2>
+                <p class="mt-2 text-sm text-slate-500">Estimasi nilai modal stok aktif saat ini.</p>
+            </article>
+            <article class="rounded-2xl border border-[#c0c8cb] bg-white p-6 shadow-sm">
+                <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">{{ $canViewSalesAndProfit ? ($isSimpleMode ? 'Filter Tanggal' : 'Performa Bisnis') : 'Periode Aktif' }}</p>
+                <h2 class="mt-3 text-3xl font-bold tracking-tight text-slate-900">{{ $canViewSalesAndProfit ? number_format($margin, 1, ',', '.').'%' : ucfirst(str_replace('_', ' ', $periodLabel)) }}</h2>
+                <p class="mt-2 text-sm text-slate-500">{{ $canViewSalesAndProfit ? ($isSimpleMode ? 'Pantau perubahan performa sederhana berdasarkan periode yang dipilih.' : 'Margin kasar antara penjualan dan pembelian.') : 'Laporan gudang difokuskan pada pembelian dan kondisi stok untuk periode terpilih.' }}</p>
             </article>
         </section>
 
         <section class="grid grid-cols-1 gap-6 xl:grid-cols-[1.15fr_0.85fr]">
-            <article class="rounded-2xl border border-[#c0c8cb] bg-white p-6 shadow-sm">
-                <h2 class="text-lg font-semibold text-slate-900">{{ $isSimpleMode ? 'Ringkasan Laporan Sederhana' : 'Ringkasan Performa Bisnis' }}</h2>
-                <div class="mt-5 space-y-4">
-                    <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
-                        <p class="text-sm font-semibold text-slate-900">{{ $isSimpleMode ? 'Penjualan dan Stok' : 'Penjualan vs Pembelian' }}</p>
-                        <p class="mt-2 text-sm leading-6 text-slate-600">
-                            {{ $isSimpleMode
-                                ? 'Halaman ini menekankan penjualan, stok, dan barang terlaris agar owner dapat mengambil keputusan cepat tanpa beban analisis yang terlalu kompleks.'
-                                : 'Gunakan perbandingan ini untuk melihat keseimbangan cashflow. Jika total pembelian tumbuh lebih cepat dari penjualan, evaluasi rotasi stok dan prioritas restock.' }}
-                        </p>
+            @if ($canViewSalesAndProfit)
+                <article class="rounded-2xl border border-[#c0c8cb] bg-white p-6 shadow-sm">
+                    <h2 class="text-lg font-semibold text-slate-900">Laba Rugi Sederhana</h2>
+                    <div class="mt-5 space-y-4">
+                        <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
+                            <dl class="grid gap-4 sm:grid-cols-3">
+                                <div>
+                                    <dt class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Pendapatan</dt>
+                                    <dd class="mt-2 text-xl font-bold text-slate-900">Rp{{ number_format($revenue, 0, ',', '.') }}</dd>
+                                </div>
+                                <div>
+                                    <dt class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Modal</dt>
+                                    <dd class="mt-2 text-xl font-bold text-slate-900">Rp{{ number_format($capital, 0, ',', '.') }}</dd>
+                                </div>
+                                <div>
+                                    <dt class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Keuntungan</dt>
+                                    <dd class="mt-2 text-xl font-bold {{ $grossProfit >= 0 ? 'text-emerald-700' : 'text-red-600' }}">Rp{{ number_format($grossProfit, 0, ',', '.') }}</dd>
+                                </div>
+                            </dl>
+                        </div>
+                        <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
+                            <p class="text-sm font-semibold text-slate-900">Rekomendasi Owner</p>
+                            <ul class="mt-3 space-y-2 text-sm text-slate-600">
+                                @if ($isSimpleMode)
+                                    <li class="flex gap-2"><span class="mt-2 h-1.5 w-1.5 rounded-full bg-[#003441]"></span><span>Periksa barang terlaris untuk memastikan stok aman selama periode berjalan.</span></li>
+                                    <li class="flex gap-2"><span class="mt-2 h-1.5 w-1.5 rounded-full bg-[#003441]"></span><span>Gunakan prediksi sederhana untuk menentukan restock tanpa analisis terlalu dalam.</span></li>
+                                    <li class="flex gap-2"><span class="mt-2 h-1.5 w-1.5 rounded-full bg-[#003441]"></span><span>Evaluasi stok minimum agar produk cepat laku tidak sering kosong.</span></li>
+                                @else
+                                    <li class="flex gap-2"><span class="mt-2 h-1.5 w-1.5 rounded-full bg-[#003441]"></span><span>Fokuskan pembelian ulang pada produk dengan stok kritis dan penjualan cepat.</span></li>
+                                    <li class="flex gap-2"><span class="mt-2 h-1.5 w-1.5 rounded-full bg-[#003441]"></span><span>Tinjau supplier dengan nilai pembelian tertinggi untuk negosiasi harga.</span></li>
+                                    <li class="flex gap-2"><span class="mt-2 h-1.5 w-1.5 rounded-full bg-[#003441]"></span><span>Pantau korelasi tren penjualan dengan prediksi stok agar pengadaan lebih presisi.</span></li>
+                                @endif
+                            </ul>
+                        </div>
                     </div>
-                    <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
-                        <p class="text-sm font-semibold text-slate-900">Rekomendasi Owner</p>
-                        <ul class="mt-3 space-y-2 text-sm text-slate-600">
-                            @if ($isSimpleMode)
-                                <li class="flex gap-2"><span class="mt-2 h-1.5 w-1.5 rounded-full bg-[#003441]"></span><span>Periksa barang terlaris untuk memastikan stok aman selama periode berjalan.</span></li>
-                                <li class="flex gap-2"><span class="mt-2 h-1.5 w-1.5 rounded-full bg-[#003441]"></span><span>Gunakan prediksi sederhana untuk menentukan restock tanpa analisis terlalu dalam.</span></li>
-                                <li class="flex gap-2"><span class="mt-2 h-1.5 w-1.5 rounded-full bg-[#003441]"></span><span>Evaluasi stok minimum agar produk cepat laku tidak sering kosong.</span></li>
-                            @else
-                                <li class="flex gap-2"><span class="mt-2 h-1.5 w-1.5 rounded-full bg-[#003441]"></span><span>Fokuskan pembelian ulang pada produk dengan stok kritis dan penjualan cepat.</span></li>
-                                <li class="flex gap-2"><span class="mt-2 h-1.5 w-1.5 rounded-full bg-[#003441]"></span><span>Tinjau supplier dengan nilai pembelian tertinggi untuk negosiasi harga.</span></li>
-                                <li class="flex gap-2"><span class="mt-2 h-1.5 w-1.5 rounded-full bg-[#003441]"></span><span>Pantau korelasi tren penjualan dengan prediksi stok agar pengadaan lebih presisi.</span></li>
-                            @endif
-                        </ul>
+                </article>
+            @else
+                <article class="rounded-2xl border border-[#c0c8cb] bg-white p-6 shadow-sm">
+                    <h2 class="text-lg font-semibold text-slate-900">Ringkasan Gudang</h2>
+                    <div class="mt-5 space-y-4">
+                        <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
+                            <dl class="grid gap-4 sm:grid-cols-2">
+                                <div>
+                                    <dt class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Total Pembelian</dt>
+                                    <dd class="mt-2 text-xl font-bold text-slate-900">Rp{{ number_format($purchaseTotal, 0, ',', '.') }}</dd>
+                                </div>
+                                <div>
+                                    <dt class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Nilai Modal Stok</dt>
+                                    <dd class="mt-2 text-xl font-bold text-slate-900">Rp{{ number_format($stockValue, 0, ',', '.') }}</dd>
+                                </div>
+                            </dl>
+                        </div>
+                        <div class="rounded-xl border border-slate-200 bg-[#f9f9fa] p-4">
+                            <p class="text-sm font-semibold text-slate-900">Catatan Operasional</p>
+                            <ul class="mt-3 space-y-2 text-sm text-slate-600">
+                                <li class="flex gap-2"><span class="mt-2 h-1.5 w-1.5 rounded-full bg-[#003441]"></span><span>Pantau stok kritis dan jadwalkan pembelian ulang lebih awal.</span></li>
+                                <li class="flex gap-2"><span class="mt-2 h-1.5 w-1.5 rounded-full bg-[#003441]"></span><span>Gunakan laporan pembelian untuk memeriksa pemasok dan nilai modal masuk.</span></li>
+                            </ul>
+                        </div>
                     </div>
-                </div>
-            </article>
+                </article>
+            @endif
 
             <article class="rounded-2xl border border-[#c0c8cb] bg-white p-6 shadow-sm">
                 <h2 class="text-lg font-semibold text-slate-900">{{ $isSimpleMode ? 'Filter Tanggal Aktif' : 'Filter Periode Aktif' }}</h2>
@@ -112,6 +128,124 @@
                     </div>
                 </div>
             </article>
+        </section>
+
+        @if ($canViewSalesAndProfit)
+            <section class="overflow-hidden rounded-2xl border border-[#c0c8cb] bg-white shadow-sm">
+                <div class="border-b border-[#c0c8cb] px-6 py-4">
+                    <h2 class="text-lg font-semibold text-slate-900">Laporan Penjualan</h2>
+                    <p class="mt-1 text-sm text-slate-500">Transaksi penjualan pada periode {{ $periodLabel }}.</p>
+                </div>
+                <div class="overflow-x-auto">
+                    <table class="min-w-[860px] w-full text-left text-sm">
+                        <thead class="bg-[#f3f4f5] text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">
+                            <tr>
+                                <th class="px-6 py-3">Kode</th>
+                                <th class="px-6 py-3">Kasir</th>
+                                <th class="px-6 py-3">Tanggal</th>
+                                <th class="px-6 py-3">Total Item</th>
+                                <th class="px-6 py-3">Total</th>
+                                <th class="px-6 py-3">Status</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-slate-200">
+                            @forelse ($sales as $sale)
+                                <tr class="transition hover:bg-slate-50">
+                                    <td class="px-6 py-4 font-semibold text-slate-900">{{ $sale->kode_transaksi }}</td>
+                                    <td class="px-6 py-4 text-slate-600">{{ $sale->kasir?->name ?? '-' }}</td>
+                                    <td class="px-6 py-4 text-slate-600">{{ $sale->tanggal_transaksi?->format('d/m/Y H:i') }}</td>
+                                    <td class="px-6 py-4 text-slate-600">{{ $sale->total_item }}</td>
+                                    <td class="px-6 py-4 font-semibold text-slate-900">Rp{{ number_format((float) $sale->total_bayar, 0, ',', '.') }}</td>
+                                    <td class="px-6 py-4 text-slate-600">{{ ucfirst($sale->status) }}</td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="6" class="px-6 py-8 text-center text-slate-500">Belum ada transaksi penjualan pada periode ini.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        @endif
+
+        @if ($canViewPurchases)
+            <section class="overflow-hidden rounded-2xl border border-[#c0c8cb] bg-white shadow-sm">
+                <div class="border-b border-[#c0c8cb] px-6 py-4">
+                    <h2 class="text-lg font-semibold text-slate-900">Laporan Pembelian</h2>
+                    <p class="mt-1 text-sm text-slate-500">Pembelian supplier pada periode {{ $periodLabel }}.</p>
+                </div>
+                <div class="overflow-x-auto">
+                    <table class="min-w-[860px] w-full text-left text-sm">
+                        <thead class="bg-[#f3f4f5] text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">
+                            <tr>
+                                <th class="px-6 py-3">Kode</th>
+                                <th class="px-6 py-3">Supplier</th>
+                                <th class="px-6 py-3">Dicatat Oleh</th>
+                                <th class="px-6 py-3">Tanggal</th>
+                                <th class="px-6 py-3">Total</th>
+                                <th class="px-6 py-3">Status</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-slate-200">
+                            @forelse ($purchases as $purchase)
+                                <tr class="transition hover:bg-slate-50">
+                                    <td class="px-6 py-4 font-semibold text-slate-900">{{ $purchase->kode_pembelian }}</td>
+                                    <td class="px-6 py-4 text-slate-600">{{ $purchase->supplier?->nama_supplier ?? '-' }}</td>
+                                    <td class="px-6 py-4 text-slate-600">{{ $purchase->pengguna?->name ?? '-' }}</td>
+                                    <td class="px-6 py-4 text-slate-600">{{ $purchase->tanggal_pembelian?->format('d/m/Y H:i') }}</td>
+                                    <td class="px-6 py-4 font-semibold text-slate-900">Rp{{ number_format((float) $purchase->total_bayar, 0, ',', '.') }}</td>
+                                    <td class="px-6 py-4 text-slate-600">{{ ucfirst($purchase->status) }}</td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="6" class="px-6 py-8 text-center text-slate-500">Belum ada pembelian pada periode ini.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        @endif
+
+        <section class="overflow-hidden rounded-2xl border border-[#c0c8cb] bg-white shadow-sm">
+            <div class="border-b border-[#c0c8cb] px-6 py-4">
+                <h2 class="text-lg font-semibold text-slate-900">Laporan Stok</h2>
+                <p class="mt-1 text-sm text-slate-500">Kondisi stok produk aktif saat ini.</p>
+            </div>
+            <div class="overflow-x-auto">
+                <table class="min-w-[980px] w-full text-left text-sm">
+                    <thead class="bg-[#f3f4f5] text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">
+                        <tr>
+                            <th class="px-6 py-3">Produk</th>
+                            <th class="px-6 py-3">Kategori</th>
+                            <th class="px-6 py-3">Supplier</th>
+                            <th class="px-6 py-3">Stok</th>
+                            <th class="px-6 py-3">Min.</th>
+                            <th class="px-6 py-3">Nilai Modal</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-slate-200">
+                        @forelse ($stockProducts as $product)
+                            <tr class="transition hover:bg-slate-50">
+                                <td class="px-6 py-4">
+                                    <p class="font-semibold text-slate-900">{{ $product->nama_produk }}</p>
+                                    <p class="mt-1 text-xs text-slate-500">{{ $product->kode_produk }}</p>
+                                </td>
+                                <td class="px-6 py-4 text-slate-600">{{ $product->kategori?->nama_kategori ?? '-' }}</td>
+                                <td class="px-6 py-4 text-slate-600">{{ $product->supplier?->nama_supplier ?? '-' }}</td>
+                                <td class="px-6 py-4 font-semibold text-slate-900">{{ $product->stok }} {{ $product->satuan }}</td>
+                                <td class="px-6 py-4 text-slate-600">{{ $product->stok_minimum }} {{ $product->satuan }}</td>
+                                <td class="px-6 py-4 font-semibold text-slate-900">Rp{{ number_format($product->stok * (float) $product->harga_beli, 0, ',', '.') }}</td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="6" class="px-6 py-8 text-center text-slate-500">Belum ada data stok produk.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
         </section>
     </div>
 @endsection

--- a/resources/views/stocks/index.blade.php
+++ b/resources/views/stocks/index.blade.php
@@ -11,7 +11,9 @@
     ? 'Daftar produk dengan stok saat ini berada di bawah atau sama dengan batas minimum.'
     : ($isSimpleMode
         ? 'Pantau ringkasan stok barang, stok masuk/keluar, stok minimum, dan histori pergerakan stok sederhana.'
-        : 'Pantau data stok utama, stok minimum, histori pergerakan stok, dan kontrol stok lebih detail untuk owner mode lengkap.'))
+        : ($canManageStock
+            ? 'Pantau data stok utama, stok minimum, histori pergerakan stok, dan kontrol stok lebih detail untuk operasional gudang.'
+            : 'Pantau histori stok kritis dan pergerakan barang untuk monitoring owner mode lengkap.')))
 
 @section('page_actions')
     @if ($canManageStock)
@@ -125,9 +127,13 @@
                             <tr class="transition hover:bg-slate-50">
                                 <td class="px-6 py-4 text-slate-600">{{ $movement->tanggal_pergerakan?->format('d/m/Y H:i') }}</td>
                                 <td class="px-6 py-4">
-                                    <a href="{{ route('stocks.show', $movement) }}" class="font-semibold text-slate-900 transition hover:text-[#003441]">
-                                        {{ $movement->produk?->nama_produk ?? '-' }}
-                                    </a>
+                                    @if ($canManageStock)
+                                        <a href="{{ route('stocks.show', $movement) }}" class="font-semibold text-slate-900 transition hover:text-[#003441]">
+                                            {{ $movement->produk?->nama_produk ?? '-' }}
+                                        </a>
+                                    @else
+                                        <span class="font-semibold text-slate-900">{{ $movement->produk?->nama_produk ?? '-' }}</span>
+                                    @endif
                                 </td>
                                 <td class="px-6 py-4 text-slate-600">{{ ucfirst($movement->jenis_pergerakan) }}</td>
                                 <td class="px-6 py-4 font-semibold text-slate-900">{{ $movement->qty }}</td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,31 +33,44 @@ Route::middleware('auth')->group(function (): void {
         Route::get('/register-user', [AuthController::class, 'showUserRegisterForm'])->name('users.register');
         Route::post('/register-user', [AuthController::class, 'registerUser'])->name('users.register.process');
         Route::resource('users', UserController::class);
+    });
+
+    Route::middleware('mode.access:reports')->group(function (): void {
         Route::resource('reports', ReportController::class)->only(['index']);
+    });
+
+    Route::middleware('mode.access:inventory-manage')->group(function (): void {
+        Route::resource('categories', CategoryController::class)->only(['create', 'store', 'edit', 'update', 'destroy']);
+        Route::resource('products', ProductController::class)->only(['create', 'store', 'edit', 'update', 'destroy']);
+        Route::resource('forecasts', ForecastController::class)->only(['create', 'store', 'edit', 'update', 'destroy']);
     });
 
     Route::middleware('mode.access:stock-read')->group(function (): void {
         Route::get('/stok', [StockController::class, 'index'])->name('stocks.role-home');
-        Route::resource('products', ProductController::class)->only(['index']);
     });
 
-    Route::middleware('mode.access:inventory')->group(function (): void {
-        Route::resource('categories', CategoryController::class);
+    Route::middleware('mode.access:product-read')->group(function (): void {
+        Route::resource('products', ProductController::class)->only(['index', 'show']);
+    });
+
+    Route::middleware('mode.access:inventory-read')->group(function (): void {
+        Route::resource('categories', CategoryController::class)->only(['index', 'show']);
+        Route::resource('forecasts', ForecastController::class)->only(['index', 'show']);
+    });
+
+    Route::middleware('mode.access:supplier-manage')->group(function (): void {
         Route::resource('suppliers', SupplierController::class);
-        Route::resource('products', ProductController::class)->only(['create', 'store', 'edit', 'update', 'destroy']);
-        Route::resource('stocks', StockController::class)->only(['index', 'create', 'store', 'show']);
-        Route::resource('forecasts', ForecastController::class);
-    });
-
-    Route::middleware('mode.access:stock-read')->group(function (): void {
-        Route::resource('products', ProductController::class)->only(['show']);
     });
 
     Route::middleware('mode.access:low-stock')->group(function (): void {
         Route::get('/stok/notifikasi', [StockController::class, 'notifications'])->name('stocks.notifications');
     });
 
-    Route::middleware('mode.access:warehouse')->group(function (): void {
+    Route::middleware('mode.access:stock-manage')->group(function (): void {
+        Route::resource('stocks', StockController::class)->only(['index', 'create', 'store', 'show']);
+    });
+
+    Route::middleware('mode.access:purchase-manage')->group(function (): void {
         Route::resource('purchases', PurchaseController::class);
     });
 

--- a/tests/Feature/CategoryManagementRoleModeTest.php
+++ b/tests/Feature/CategoryManagementRoleModeTest.php
@@ -93,6 +93,38 @@ class CategoryManagementRoleModeTest extends TestCase
         ]);
     }
 
+    public function test_owner_lengkap_can_only_view_categories(): void
+    {
+        $owner = User::factory()->create([
+            'role' => 'owner',
+            'mode_app' => 'lengkap',
+        ]);
+
+        $category = Category::create([
+            'nama_kategori' => 'Frozen Food',
+            'slug' => 'frozen-food',
+        ]);
+
+        $this->actingAs($owner)
+            ->get('/categories')
+            ->assertOk()
+            ->assertSee($category->nama_kategori)
+            ->assertDontSee('Tambah Kategori')
+            ->assertDontSee('Edit');
+
+        $this->actingAs($owner)
+            ->get(route('categories.show', $category))
+            ->assertOk()
+            ->assertSee($category->nama_kategori)
+            ->assertDontSee('Edit Kategori');
+
+        $this->actingAs($owner)->get('/categories/create')->assertForbidden();
+        $this->actingAs($owner)->post('/categories', ['nama_kategori' => 'Baru'])->assertForbidden();
+        $this->actingAs($owner)->get(route('categories.edit', $category))->assertForbidden();
+        $this->actingAs($owner)->put(route('categories.update', $category), ['nama_kategori' => 'Baru'])->assertForbidden();
+        $this->actingAs($owner)->delete(route('categories.destroy', $category))->assertForbidden();
+    }
+
     public function test_gudang_sederhana_cannot_access_categories(): void
     {
         $gudang = User::factory()->create([
@@ -135,7 +167,7 @@ class CategoryManagementRoleModeTest extends TestCase
     {
         $owner = User::factory()->create([
             'role' => 'owner',
-            'mode_app' => 'lengkap',
+            'mode_app' => 'sederhana',
         ]);
 
         Category::create([

--- a/tests/Feature/ProductManagementRoleModeTest.php
+++ b/tests/Feature/ProductManagementRoleModeTest.php
@@ -79,6 +79,38 @@ class ProductManagementRoleModeTest extends TestCase
         ]);
     }
 
+    public function test_owner_lengkap_can_only_view_product_data(): void
+    {
+        $owner = User::factory()->create([
+            'role' => 'owner',
+            'mode_app' => 'lengkap',
+        ]);
+        $category = $this->createCategory(['nama_kategori' => 'Minuman', 'slug' => 'minuman']);
+        $supplier = $this->createSupplier(['nama_supplier' => 'Supplier Monitoring']);
+        $product = $this->createProduct($category, $supplier, [
+            'nama_produk' => 'Teh Botol',
+        ]);
+
+        $this->actingAs($owner)
+            ->get('/products')
+            ->assertOk()
+            ->assertSee($product->nama_produk)
+            ->assertDontSee('Tambah Produk')
+            ->assertDontSee('Edit');
+
+        $this->actingAs($owner)
+            ->get(route('products.show', $product))
+            ->assertOk()
+            ->assertSee($product->nama_produk)
+            ->assertDontSee('Edit Produk');
+
+        $this->actingAs($owner)->get('/products/create')->assertForbidden();
+        $this->actingAs($owner)->post('/products', [])->assertForbidden();
+        $this->actingAs($owner)->get(route('products.edit', $product))->assertForbidden();
+        $this->actingAs($owner)->put(route('products.update', $product), [])->assertForbidden();
+        $this->actingAs($owner)->delete(route('products.destroy', $product))->assertForbidden();
+    }
+
     public function test_kasir_can_only_view_product_data_and_cannot_manage_products(): void
     {
         $kasir = User::factory()->create([
@@ -126,7 +158,7 @@ class ProductManagementRoleModeTest extends TestCase
     {
         $owner = User::factory()->create([
             'role' => 'owner',
-            'mode_app' => 'lengkap',
+            'mode_app' => 'sederhana',
         ]);
 
         $this->actingAs($owner)

--- a/tests/Feature/PurchaseManagementStockUpdateTest.php
+++ b/tests/Feature/PurchaseManagementStockUpdateTest.php
@@ -15,17 +15,17 @@ class PurchaseManagementStockUpdateTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_owner_lengkap_can_create_purchase_with_multiple_items_and_stock_updates(): void
+    public function test_gudang_lengkap_can_create_purchase_with_multiple_items_and_stock_updates(): void
     {
-        $owner = User::factory()->create([
-            'role' => 'owner',
+        $gudang = User::factory()->create([
+            'role' => 'gudang',
             'mode_app' => 'lengkap',
         ]);
         $supplier = $this->createSupplier();
         $firstProduct = $this->createProduct(['stok' => 4, 'harga_beli' => 10000]);
         $secondProduct = $this->createProduct(['stok' => 2, 'harga_beli' => 7000]);
 
-        $response = $this->actingAs($owner)->post('/purchases', [
+        $response = $this->actingAs($gudang)->post('/purchases', [
             'supplier_id' => $supplier->id,
             'items' => [
                 [
@@ -51,7 +51,7 @@ class PurchaseManagementStockUpdateTest extends TestCase
         $this->assertDatabaseHas('purchases', [
             'id' => $purchase->id,
             'supplier_id' => $supplier->id,
-            'user_id' => $owner->id,
+            'user_id' => $gudang->id,
             'subtotal' => 73000,
             'diskon' => 2000,
             'ongkir' => 5000,
@@ -89,7 +89,7 @@ class PurchaseManagementStockUpdateTest extends TestCase
 
         $this->assertDatabaseHas('stock_movements', [
             'product_id' => $firstProduct->id,
-            'user_id' => $owner->id,
+            'user_id' => $gudang->id,
             'jenis_pergerakan' => 'masuk',
             'qty' => 3,
             'stok_sebelum' => 4,
@@ -100,7 +100,7 @@ class PurchaseManagementStockUpdateTest extends TestCase
 
         $this->assertDatabaseHas('stock_movements', [
             'product_id' => $secondProduct->id,
-            'user_id' => $owner->id,
+            'user_id' => $gudang->id,
             'jenis_pergerakan' => 'masuk',
             'qty' => 5,
             'stok_sebelum' => 2,
@@ -150,14 +150,14 @@ class PurchaseManagementStockUpdateTest extends TestCase
 
     public function test_purchase_requires_at_least_one_item_with_quantity(): void
     {
-        $owner = User::factory()->create([
-            'role' => 'owner',
+        $gudang = User::factory()->create([
+            'role' => 'gudang',
             'mode_app' => 'lengkap',
         ]);
         $supplier = $this->createSupplier();
         $product = $this->createProduct();
 
-        $this->actingAs($owner)
+        $this->actingAs($gudang)
             ->from('/purchases/create')
             ->post('/purchases', [
                 'supplier_id' => $supplier->id,
@@ -174,6 +174,18 @@ class PurchaseManagementStockUpdateTest extends TestCase
 
         $this->assertEquals(0, Purchase::query()->count());
         $this->assertEquals(0, StockMovement::query()->count());
+    }
+
+    public function test_owner_lengkap_cannot_access_purchase_routes(): void
+    {
+        $owner = User::factory()->create([
+            'role' => 'owner',
+            'mode_app' => 'lengkap',
+        ]);
+
+        $this->actingAs($owner)->get('/purchases')->assertForbidden();
+        $this->actingAs($owner)->get('/purchases/create')->assertForbidden();
+        $this->actingAs($owner)->post('/purchases', [])->assertForbidden();
     }
 
     private function createSupplier(): Supplier

--- a/tests/Feature/ReportAccessAndContentTest.php
+++ b/tests/Feature/ReportAccessAndContentTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\Purchase;
+use App\Models\Supplier;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReportAccessAndContentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_can_view_sales_purchase_stock_and_profit_reports_by_period(): void
+    {
+        $owner = User::factory()->create([
+            'role' => 'owner',
+            'mode_app' => 'lengkap',
+        ]);
+        $product = $this->createProduct([
+            'nama_produk' => 'Produk Laporan',
+            'stok' => 12,
+            'harga_beli' => 10000,
+        ]);
+        $supplier = Supplier::findOrFail($product->supplier_id);
+
+        Transaction::create([
+            'kode_transaksi' => 'TRX-IN-001',
+            'user_id' => $owner->id,
+            'tanggal_transaksi' => now()->subDays(2),
+            'total_item' => 2,
+            'subtotal' => 40000,
+            'total_bayar' => 40000,
+            'nominal_bayar' => 40000,
+            'kembalian' => 0,
+            'status' => 'selesai',
+        ]);
+
+        Transaction::create([
+            'kode_transaksi' => 'TRX-OUT-OLD',
+            'user_id' => $owner->id,
+            'tanggal_transaksi' => now()->subDays(45),
+            'total_item' => 1,
+            'subtotal' => 20000,
+            'total_bayar' => 20000,
+            'nominal_bayar' => 20000,
+            'kembalian' => 0,
+            'status' => 'selesai',
+        ]);
+
+        Purchase::create([
+            'kode_pembelian' => 'PO-IN-001',
+            'supplier_id' => $supplier->id,
+            'user_id' => $owner->id,
+            'tanggal_pembelian' => now()->subDays(1),
+            'subtotal' => 25000,
+            'diskon' => 0,
+            'ongkir' => 5000,
+            'total_bayar' => 30000,
+            'status' => 'selesai',
+        ]);
+
+        Purchase::create([
+            'kode_pembelian' => 'PO-OLD-001',
+            'supplier_id' => $supplier->id,
+            'user_id' => $owner->id,
+            'tanggal_pembelian' => now()->subDays(50),
+            'subtotal' => 15000,
+            'diskon' => 0,
+            'ongkir' => 0,
+            'total_bayar' => 15000,
+            'status' => 'selesai',
+        ]);
+
+        $this->actingAs($owner)
+            ->get('/reports?period=30_hari')
+            ->assertOk()
+            ->assertSee('TRX-IN-001')
+            ->assertDontSee('TRX-OUT-OLD')
+            ->assertSee('PO-IN-001')
+            ->assertDontSee('PO-OLD-001')
+            ->assertSee('Produk Laporan')
+            ->assertSee('Rp40.000')
+            ->assertSee('Rp30.000')
+            ->assertSee('Rp10.000');
+    }
+
+    public function test_owner_can_change_report_period_filter(): void
+    {
+        $owner = User::factory()->create([
+            'role' => 'owner',
+            'mode_app' => 'sederhana',
+        ]);
+
+        $this->actingAs($owner)
+            ->get('/reports?period=7_hari')
+            ->assertOk()
+            ->assertSee('7 hari terakhir');
+    }
+
+    public function test_kasir_cannot_access_owner_reports(): void
+    {
+        $kasir = User::factory()->create([
+            'role' => 'kasir',
+            'mode_app' => 'sederhana',
+        ]);
+
+        $this->actingAs($kasir)
+            ->get('/reports')
+            ->assertForbidden();
+    }
+
+    public function test_gudang_lengkap_can_view_stock_and_purchase_reports_only(): void
+    {
+        $gudang = User::factory()->create([
+            'role' => 'gudang',
+            'mode_app' => 'lengkap',
+        ]);
+        $product = $this->createProduct([
+            'nama_produk' => 'Produk Gudang',
+            'stok' => 8,
+        ]);
+        $supplier = Supplier::findOrFail($product->supplier_id);
+
+        Purchase::create([
+            'kode_pembelian' => 'PO-GDG-001',
+            'supplier_id' => $supplier->id,
+            'user_id' => $gudang->id,
+            'tanggal_pembelian' => now()->subDays(2),
+            'subtotal' => 18000,
+            'diskon' => 0,
+            'ongkir' => 2000,
+            'total_bayar' => 20000,
+            'status' => 'selesai',
+        ]);
+
+        Transaction::create([
+            'kode_transaksi' => 'TRX-GDG-001',
+            'user_id' => $gudang->id,
+            'tanggal_transaksi' => now()->subDay(),
+            'total_item' => 1,
+            'subtotal' => 15000,
+            'total_bayar' => 15000,
+            'nominal_bayar' => 15000,
+            'kembalian' => 0,
+            'status' => 'selesai',
+        ]);
+
+        $this->actingAs($gudang)
+            ->get('/reports?period=30_hari')
+            ->assertOk()
+            ->assertSee('Laporan Pembelian')
+            ->assertSee('Laporan Stok')
+            ->assertSee('PO-GDG-001')
+            ->assertSee('Produk Gudang')
+            ->assertDontSee('Laporan Penjualan')
+            ->assertDontSee('Laba Rugi Sederhana')
+            ->assertDontSee('TRX-GDG-001');
+    }
+
+    private function createProduct(array $attributes = []): Product
+    {
+        $category = Category::create([
+            'nama_kategori' => fake()->unique()->word(),
+            'slug' => fake()->unique()->slug(),
+            'is_active' => true,
+        ]);
+
+        $supplier = Supplier::create([
+            'nama_supplier' => fake()->unique()->company(),
+            'nama_kontak' => fake()->name(),
+            'telepon' => fake()->numerify('08##########'),
+            'alamat' => fake()->address(),
+            'is_active' => true,
+        ]);
+
+        return Product::create($attributes + [
+            'category_id' => $category->id,
+            'supplier_id' => $supplier->id,
+            'kode_produk' => 'PRD-'.fake()->unique()->numerify('####'),
+            'nama_produk' => 'Produk '.fake()->unique()->word(),
+            'slug' => fake()->unique()->slug(),
+            'satuan' => 'pcs',
+            'harga_beli' => 10000,
+            'harga_jual' => 20000,
+            'stok' => 0,
+            'stok_minimum' => 2,
+            'is_active' => true,
+        ]);
+    }
+}

--- a/tests/Feature/RouteRoleModeAccessTest.php
+++ b/tests/Feature/RouteRoleModeAccessTest.php
@@ -30,7 +30,7 @@ class RouteRoleModeAccessTest extends TestCase
         $this->actingAs($kasir)->get('/transactions/create')->assertForbidden();
     }
 
-    public function test_gudang_lengkap_can_access_warehouse_features_but_not_owner_or_sales_features(): void
+    public function test_gudang_lengkap_can_access_warehouse_and_report_features_but_not_owner_or_sales_features(): void
     {
         $gudang = User::factory()->create([
             'role' => 'gudang',
@@ -42,10 +42,10 @@ class RouteRoleModeAccessTest extends TestCase
         $this->actingAs($gudang)->get('/suppliers')->assertOk();
         $this->actingAs($gudang)->get('/purchases')->assertOk();
         $this->actingAs($gudang)->get('/stok/notifikasi')->assertOk();
+        $this->actingAs($gudang)->get('/reports')->assertOk();
 
         $this->actingAs($gudang)->get('/pos')->assertForbidden();
         $this->actingAs($gudang)->get('/users')->assertForbidden();
-        $this->actingAs($gudang)->get('/reports')->assertForbidden();
     }
 
     public function test_gudang_sederhana_is_not_a_valid_mode_for_gudang_features(): void
@@ -80,8 +80,17 @@ class RouteRoleModeAccessTest extends TestCase
             'mode_app' => 'lengkap',
         ]);
 
-        $this->actingAs($ownerLengkap)->get('/suppliers')->assertOk();
-        $this->actingAs($ownerLengkap)->get('/purchases')->assertOk();
+        $this->actingAs($ownerLengkap)->get('/dashboard')->assertOk();
+        $this->actingAs($ownerLengkap)->get('/products')->assertOk();
+        $this->actingAs($ownerLengkap)->get('/categories')->assertOk();
+        $this->actingAs($ownerLengkap)->get('/reports')->assertOk();
+        $this->actingAs($ownerLengkap)->get('/forecasts')->assertOk();
+        $this->actingAs($ownerLengkap)->get('/stok')->assertForbidden();
+        $this->actingAs($ownerLengkap)->get('/products/create')->assertForbidden();
+        $this->actingAs($ownerLengkap)->get('/categories/create')->assertForbidden();
+        $this->actingAs($ownerLengkap)->get('/forecasts/create')->assertForbidden();
+        $this->actingAs($ownerLengkap)->get('/suppliers')->assertForbidden();
+        $this->actingAs($ownerLengkap)->get('/purchases')->assertForbidden();
     }
 
     public function test_owner_without_mode_is_redirected_to_mode_selection_for_protected_routes(): void

--- a/tests/Feature/SalesForecastMovingAverageTest.php
+++ b/tests/Feature/SalesForecastMovingAverageTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\SalesForecast;
+use App\Models\Supplier;
+use App\Models\Transaction;
+use App\Models\TransactionItem;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SalesForecastMovingAverageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_sederhana_can_generate_sales_forecast_from_recent_sales_history(): void
+    {
+        $owner = User::factory()->create([
+            'role' => 'owner',
+            'mode_app' => 'sederhana',
+        ]);
+        $product = $this->createProduct([
+            'nama_produk' => 'Produk Forecast',
+            'stok' => 4,
+            'satuan' => 'pcs',
+        ]);
+
+        $this->createTransactionWithItem($owner, $product, now()->subMonths(2)->startOfMonth()->addDays(2), 12);
+        $this->createTransactionWithItem($owner, $product, now()->subMonth()->startOfMonth()->addDays(5), 6);
+        $this->createTransactionWithItem($owner, $product, now()->startOfMonth()->addDays(1), 9);
+
+        $response = $this->actingAs($owner)->post('/forecasts', [
+            'product_id' => $product->id,
+            'periode_akhir' => now()->toDateString(),
+            'panjang_jendela' => 3,
+            'catatan' => '',
+        ]);
+
+        $forecast = SalesForecast::query()->first();
+
+        $response
+            ->assertRedirect(route('forecasts.show', $forecast))
+            ->assertSessionHasNoErrors();
+
+        $this->assertNotNull($forecast);
+        $this->assertSame(9.00, (float) $forecast->nilai_moving_average);
+        $this->assertSame(9, $forecast->prediksi_stok);
+        $this->assertSame(4, $forecast->stok_aktual);
+        $this->assertSame(5, $forecast->selisih_prediksi);
+
+        $this->actingAs($owner)
+            ->get('/forecasts')
+            ->assertOk()
+            ->assertSee('Produk Forecast')
+            ->assertSee('9')
+            ->assertSee('5');
+    }
+
+    public function test_gudang_lengkap_can_view_sales_forecast_list(): void
+    {
+        $gudang = User::factory()->create([
+            'role' => 'gudang',
+            'mode_app' => 'lengkap',
+        ]);
+        $product = $this->createProduct(['nama_produk' => 'Produk Gudang Forecast']);
+
+        SalesForecast::create([
+            'product_id' => $product->id,
+            'user_id' => $gudang->id,
+            'periode_awal' => now()->subMonths(2)->startOfMonth(),
+            'periode_akhir' => now()->endOfMonth(),
+            'panjang_jendela' => 3,
+            'nilai_moving_average' => 7.33,
+            'prediksi_stok' => 8,
+            'stok_aktual' => 3,
+            'selisih_prediksi' => 5,
+            'catatan' => 'Perlu restock.',
+        ]);
+
+        $this->actingAs($gudang)
+            ->get('/forecasts')
+            ->assertOk()
+            ->assertSee('Produk Gudang Forecast')
+            ->assertSee('8')
+            ->assertSee('5');
+    }
+
+    public function test_owner_lengkap_can_only_view_sales_forecast_list(): void
+    {
+        $owner = User::factory()->create([
+            'role' => 'owner',
+            'mode_app' => 'lengkap',
+        ]);
+        $product = $this->createProduct(['nama_produk' => 'Produk Owner Lengkap']);
+
+        $forecast = SalesForecast::create([
+            'product_id' => $product->id,
+            'user_id' => $owner->id,
+            'periode_awal' => now()->subMonths(2)->startOfMonth(),
+            'periode_akhir' => now()->endOfMonth(),
+            'panjang_jendela' => 3,
+            'nilai_moving_average' => 5.67,
+            'prediksi_stok' => 6,
+            'stok_aktual' => 9,
+            'selisih_prediksi' => 0,
+            'catatan' => 'Monitoring owner lengkap.',
+        ]);
+
+        $this->actingAs($owner)
+            ->get('/forecasts')
+            ->assertOk()
+            ->assertSee('Produk Owner Lengkap')
+            ->assertDontSee('Tambah Prediksi');
+
+        $this->actingAs($owner)
+            ->get(route('forecasts.show', $forecast))
+            ->assertOk()
+            ->assertSee('Produk Owner Lengkap')
+            ->assertDontSee('Edit Prediksi')
+            ->assertDontSee('Hapus');
+
+        $this->actingAs($owner)->get('/forecasts/create')->assertForbidden();
+        $this->actingAs($owner)->post('/forecasts', [])->assertForbidden();
+        $this->actingAs($owner)->get(route('forecasts.edit', $forecast))->assertForbidden();
+        $this->actingAs($owner)->delete(route('forecasts.destroy', $forecast))->assertForbidden();
+    }
+
+    public function test_kasir_cannot_access_sales_forecast_routes(): void
+    {
+        $kasir = User::factory()->create([
+            'role' => 'kasir',
+            'mode_app' => 'sederhana',
+        ]);
+
+        $this->actingAs($kasir)->get('/forecasts')->assertForbidden();
+        $this->actingAs($kasir)->get('/forecasts/create')->assertForbidden();
+        $this->actingAs($kasir)->post('/forecasts', [])->assertForbidden();
+    }
+
+    private function createProduct(array $attributes = []): Product
+    {
+        $category = Category::create([
+            'nama_kategori' => fake()->unique()->word(),
+            'slug' => fake()->unique()->slug(),
+            'is_active' => true,
+        ]);
+
+        $supplier = Supplier::create([
+            'nama_supplier' => fake()->unique()->company(),
+            'nama_kontak' => fake()->name(),
+            'telepon' => fake()->numerify('08##########'),
+            'alamat' => fake()->address(),
+            'is_active' => true,
+        ]);
+
+        return Product::create($attributes + [
+            'category_id' => $category->id,
+            'supplier_id' => $supplier->id,
+            'kode_produk' => 'PRD-'.fake()->unique()->numerify('####'),
+            'nama_produk' => 'Produk '.fake()->unique()->word(),
+            'slug' => fake()->unique()->slug(),
+            'satuan' => 'pcs',
+            'harga_beli' => 10000,
+            'harga_jual' => 15000,
+            'stok' => 0,
+            'stok_minimum' => 2,
+            'is_active' => true,
+        ]);
+    }
+
+    private function createTransactionWithItem(User $user, Product $product, \Carbon\Carbon $date, int $qty): void
+    {
+        $transaction = Transaction::create([
+            'kode_transaksi' => 'TRX-'.fake()->unique()->numerify('#####'),
+            'user_id' => $user->id,
+            'tanggal_transaksi' => $date,
+            'total_item' => $qty,
+            'subtotal' => $qty * (float) $product->harga_jual,
+            'total_bayar' => $qty * (float) $product->harga_jual,
+            'nominal_bayar' => $qty * (float) $product->harga_jual,
+            'kembalian' => 0,
+            'status' => 'selesai',
+        ]);
+
+        TransactionItem::create([
+            'transaction_id' => $transaction->id,
+            'product_id' => $product->id,
+            'nama_produk' => $product->nama_produk,
+            'qty' => $qty,
+            'harga' => $product->harga_jual,
+            'subtotal' => $qty * (float) $product->harga_jual,
+        ]);
+    }
+}

--- a/tests/Feature/SidebarRoleModeTest.php
+++ b/tests/Feature/SidebarRoleModeTest.php
@@ -48,7 +48,8 @@ class SidebarRoleModeTest extends TestCase
             ->assertSee('href="'.route('users.index').'"', false)
             ->assertSee('href="'.route('products.index').'"', false)
             ->assertSee('href="'.route('categories.index').'"', false)
-            ->assertSee('href="'.route('stocks.role-home').'"', false)
+            ->assertSee('href="'.route('users.register').'"', false)
+            ->assertDontSee('href="'.route('stocks.role-home').'"', false)
             ->assertDontSee('href="'.route('suppliers.index').'"', false)
             ->assertDontSee('href="'.route('purchases.index').'"', false)
             ->assertDontSee('href="'.route('transactions.pos').'"', false);

--- a/tests/Feature/StockManagementMovementTest.php
+++ b/tests/Feature/StockManagementMovementTest.php
@@ -68,6 +68,23 @@ class StockManagementMovementTest extends TestCase
         ]);
     }
 
+    public function test_owner_lengkap_cannot_access_stock_management(): void
+    {
+        $owner = User::factory()->create([
+            'role' => 'owner',
+            'mode_app' => 'lengkap',
+        ]);
+        $product = $this->createProduct(['stok' => 1, 'stok_minimum' => 2]);
+
+        $this->actingAs($owner)->get('/stok')->assertForbidden();
+        $this->actingAs($owner)->get('/stocks/create')->assertForbidden();
+        $this->actingAs($owner)->post('/stocks', [
+            'product_id' => $product->id,
+            'qty' => 2,
+        ])->assertForbidden();
+        $this->actingAs($owner)->get('/stok/notifikasi')->assertOk()->assertSee($product->nama_produk);
+    }
+
     public function test_kasir_can_only_view_stock_read_only(): void
     {
         $kasir = User::factory()->create([

--- a/tests/Feature/SupplierManagementRoleModeTest.php
+++ b/tests/Feature/SupplierManagementRoleModeTest.php
@@ -11,7 +11,7 @@ class SupplierManagementRoleModeTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_owner_can_access_and_crud_suppliers_in_any_mode(): void
+    public function test_owner_sederhana_can_access_and_crud_suppliers(): void
     {
         $owner = User::factory()->create([
             'role' => 'owner',
@@ -102,6 +102,28 @@ class SupplierManagementRoleModeTest extends TestCase
         ]);
     }
 
+    public function test_owner_lengkap_cannot_access_supplier_management(): void
+    {
+        $owner = User::factory()->create([
+            'role' => 'owner',
+            'mode_app' => 'lengkap',
+        ]);
+
+        $supplier = Supplier::create([
+            'nama_supplier' => 'PT Monitoring',
+            'nama_kontak' => 'Wira',
+            'telepon' => '08122222',
+            'alamat' => 'Jl. Melati 5',
+        ]);
+
+        $this->actingAs($owner)->get('/suppliers')->assertForbidden();
+        $this->actingAs($owner)->get('/suppliers/create')->assertForbidden();
+        $this->actingAs($owner)->post('/suppliers', [])->assertForbidden();
+        $this->actingAs($owner)->get(route('suppliers.edit', $supplier))->assertForbidden();
+        $this->actingAs($owner)->put(route('suppliers.update', $supplier), [])->assertForbidden();
+        $this->actingAs($owner)->delete(route('suppliers.destroy', $supplier))->assertForbidden();
+    }
+
     public function test_gudang_sederhana_cannot_access_suppliers(): void
     {
         $gudang = User::factory()->create([
@@ -148,7 +170,7 @@ class SupplierManagementRoleModeTest extends TestCase
     {
         $owner = User::factory()->create([
             'role' => 'owner',
-            'mode_app' => 'lengkap',
+            'mode_app' => 'sederhana',
         ]);
 
         $this->actingAs($owner)


### PR DESCRIPTION
  1. Tambahkan Laporan Utama Berdasarkan Data Operasional

  Perubahan:

  - app/Http/Controllers/ReportController.php
      - laporan sekarang dihitung di backend, bukan query liar di Blade
      - filter periode 7/30/90 hari
      - hitung penjualan, pembelian, nilai stok, pendapatan, modal, laba rugi sederhana
  - resources/views/reports/index.blade.php
      - tampilkan laporan penjualan per periode
      - tampilkan laporan pembelian per periode
      - tampilkan laporan stok
      - tampilkan laba rugi sederhana
      - gudang lengkap hanya melihat stok + pembelian, bukan penjualan/laba rugi
  - tests/Feature/ReportAccessAndContentTest.php
      - test owner akses laporan
      - test filter periode
      - test kasir ditolak
      - test gudang lengkap hanya lihat laporan yang relevan

  2.Implementasi Prediksi Stok Menggunakan Moving Average

  Perubahan:

  - app/Services/SalesForecastService.php
      - service baru untuk hitung prediksi stok
      - pakai Simple Moving Average
      - basis perhitungan dari histori penjualan bulanan
      - hasilkan prediksi stok, moving average, stok aktual, dan gap restock
  - app/Http/Controllers/ForecastController.php
      - forecast sekarang benar-benar jalan
      - create/store/show/edit/update/destroy aktif
      - hasil prediksi disimpan ke sales_forecasts
  - resources/views/forecasts/index.blade.php
      - daftar prediksi stok
      - ringkasan data prediksi
      - rekomendasi restock
  - resources/views/forecasts/create.blade.php
  - resources/views/forecasts/_form.blade.php
  - resources/views/forecasts/show.blade.php
  - resources/views/forecasts/edit.blade.php
      - form dipersempit ke input yang memang diperlukan
      - detail prediksi menampilkan histori per bulan, moving average, dan rekomendasi restock
  - tests/Feature/SalesForecastMovingAverageTest.php
      - test owner bisa generate prediksi
      - test hasil masuk ke sales_forecasts
      - test gudang lengkap bisa lihat prediksi
      - test kasir ditolak

  3. Rapikan Akses Owner Mode Lengkap Menjadi Read-Only untuk Monitoring Inventori

  Perubahan:

  - app/Http/Middleware/EnsureRoleModeAccess.php
      - akses dipecah lebih granular:
          - product-read
          - stock-read
          - stock-manage
          - inventory-read
          - inventory-manage
          - supplier-manage
          - purchase-manage
  - routes/web.php
      - route dipisah antara read-only dan manage
      - owner lengkap sekarang:
          - boleh lihat produk, kategori, laporan, prediksi
          - tidak boleh operasional stok, supplier, pembelian
  - resources/views/layouts/app.blade.php
      - sidebar owner lengkap diubah
      - menu Stok dihapus dari owner lengkap
  - app/Http/Controllers/ProductController.php
  - app/Http/Controllers/CategoryController.php
  - app/Http/Controllers/StockController.php
      - helper canManage... disesuaikan
      - owner lengkap jadi read-only
  - resources/views/products/index.blade.php
  - resources/views/categories/index.blade.php
  - resources/views/categories/show.blade.php
  - resources/views/stocks/index.blade.php
      - tombol tambah/edit/hapus disembunyikan untuk owner lengkap
      - copy halaman disesuaikan jadi monitoring, bukan operasional
  - Test yang disinkronkan:
      - tests/Feature/RouteRoleModeAccessTest.php
      - tests/Feature/SidebarRoleModeTest.php
      - tests/Feature/ProductManagementRoleModeTest.php
      - tests/Feature/CategoryManagementRoleModeTest.php
      - tests/Feature/StockManagementMovementTest.php
      - tests/Feature/SupplierManagementRoleModeTest.php
      - tests/Feature/PurchaseManagementStockUpdateTest.php
      - tests/Feature/SalesForecastMovingAverageTest.php
