### PR TITLE
Tambahkan reset sandi owner dan topbar judul halaman

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -21,6 +21,16 @@ class AuthController extends Controller
         return view('auth.register');
     }
 
+    public function showForgotPasswordForm(): View
+    {
+        return view('auth.forgot-password');
+    }
+
+    public function showOwnerPasswordResetForm(): View
+    {
+        return view('auth.reset-owner-password');
+    }
+
     public function showUserRegisterForm(): View
     {
         return view('auth.register-user', [

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,0 +1,55 @@
+@extends('layouts.auth')
+
+@php
+    $judulHalaman = 'Lupa Kata Sandi';
+@endphp
+
+@section('auth_heading', 'Reset sandi khusus untuk akun owner')
+
+@section('content')
+    <div class="rounded-2xl border border-slate-200 bg-white px-5 py-6 text-center shadow-sm sm:px-6">
+        <div class="mx-auto flex h-20 w-20 items-center justify-center rounded-3xl bg-[#0b4a5a]/10 text-[#0b4a5a] shadow-inner">
+            <svg class="h-10 w-10" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 10V7a4 4 0 0 0-8 0v3" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 10h12a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2Z" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2" />
+            </svg>
+        </div>
+
+        <div class="mt-5">
+            <h2 class="text-2xl font-extrabold tracking-tight text-slate-800">Lupa Kata Sandi</h2>
+            <p class="mt-2 text-sm leading-6 text-slate-500">
+                Gunakan halaman ini hanya untuk memulai proses reset sandi akun owner.
+            </p>
+        </div>
+
+        <div class="mt-5 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-4 text-left text-amber-900">
+            <div class="flex gap-3">
+                <span class="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-700">
+                    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v4m0 4h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+                    </svg>
+                </span>
+                <div>
+                    <p class="text-sm font-bold">Peringatan akses reset sandi</p>
+                    <p class="mt-1 text-sm leading-6">
+                        Lupa kata sandi hanya berlaku untuk owner. Jika pegawai lupa kata sandi, silakan hubungi owner.
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <div class="mt-6 space-y-3">
+            <a
+                href="{{ route('password.owner-reset') }}"
+                class="inline-flex h-11 w-full items-center justify-center rounded-md bg-[#083d4b] px-4 text-sm font-bold text-white shadow-sm transition hover:bg-[#062f39]"
+            >
+                Lanjutkan Reset Sandi Owner
+            </a>
+
+            <a href="{{ route('login') }}" class="inline-flex text-sm font-bold text-[#0b4a5a] hover:underline">
+                Kembali ke halaman masuk
+            </a>
+        </div>
+    </div>
+@endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -75,7 +75,7 @@
                     <input type="checkbox" name="remember" value="1" class="h-4 w-4 rounded border-slate-300 text-[#0b4a5a] focus:ring-[#0b4a5a]" />
                     <span>Ingat saya</span>
                 </label>
-                <a href="#" class="text-xs font-bold text-[#0b4a5a] hover:underline">Lupa kata sandi?</a>
+                <a href="/lupa-kata-sandi" class="text-xs font-bold text-[#0b4a5a] hover:underline">Lupa kata sandi?</a>
             </div>
 
             <button type="submit" data-loading-text="Masuk..." class="mt-1 h-11 w-full rounded-md bg-[#083d4b] text-sm font-bold text-white transition hover:bg-[#062f39]">

--- a/resources/views/auth/reset-owner-password.blade.php
+++ b/resources/views/auth/reset-owner-password.blade.php
@@ -1,0 +1,143 @@
+@extends('layouts.auth')
+
+@php
+    $judulHalaman = 'Reset Sandi Owner';
+@endphp
+
+@section('auth_heading', 'Verifikasi owner sebelum mengganti sandi')
+
+@section('content')
+    <div class="rounded-2xl border border-slate-200 bg-white px-5 py-6 shadow-sm sm:px-6">
+        <div class="text-center">
+            <div class="mx-auto flex h-20 w-20 items-center justify-center rounded-3xl bg-[#0b4a5a]/10 text-[#0b4a5a] shadow-inner">
+                <svg class="h-10 w-10" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 10V7a4 4 0 0 0-8 0v3" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 10h12a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2Z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14.5v2.5" />
+                </svg>
+            </div>
+
+            <h2 class="mt-5 text-2xl font-extrabold tracking-tight text-slate-800">Reset Sandi Owner</h2>
+            <p class="mt-2 text-sm leading-6 text-slate-500">
+                Masukkan email owner, kode verifikasi, dan sandi baru untuk melanjutkan proses reset.
+            </p>
+        </div>
+
+        <div class="mt-5 rounded-2xl border border-sky-100 bg-sky-50 px-4 py-3 text-sm leading-6 text-sky-900">
+            Pastikan email yang dimasukkan adalah email akun owner. Pegawai tetap perlu menghubungi owner jika lupa kata sandi.
+        </div>
+
+        <form action="#" method="POST" class="mt-6 space-y-4">
+            @csrf
+
+            <div class="space-y-1.5">
+                <label for="owner_email" class="block text-sm font-bold text-slate-700">Email Owner</label>
+                <div class="relative">
+                    <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 0 0 2.22 0L21 8" />
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 19h14a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2Z" />
+                        </svg>
+                    </div>
+                    <input
+                        id="owner_email"
+                        name="owner_email"
+                        type="email"
+                        placeholder="owner@email.com"
+                        class="block h-11 w-full rounded-md border border-slate-300 bg-white pl-9 pr-3 text-sm text-slate-700 outline-none transition focus:border-[#0b4a5a] focus:ring-2 focus:ring-[#0b4a5a]/10 placeholder:text-slate-400"
+                    />
+                </div>
+            </div>
+
+            <div class="space-y-1.5">
+                <label for="verification_code" class="block text-sm font-bold text-slate-700">Kode Verifikasi</label>
+                <div class="relative">
+                    <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6M8 4h8l2 3v13H6V7l2-3Z" />
+                        </svg>
+                    </div>
+                    <input
+                        id="verification_code"
+                        name="verification_code"
+                        type="text"
+                        inputmode="numeric"
+                        placeholder="Masukkan kode verifikasi"
+                        class="block h-11 w-full rounded-md border border-slate-300 bg-white pl-9 pr-3 text-sm text-slate-700 outline-none transition focus:border-[#0b4a5a] focus:ring-2 focus:ring-[#0b4a5a]/10 placeholder:text-slate-400"
+                    />
+                </div>
+            </div>
+
+            <div class="grid gap-4 sm:grid-cols-2">
+                <div class="space-y-1.5">
+                    <label for="new_password" class="block text-sm font-bold text-slate-700">Sandi Baru</label>
+                    <div class="relative">
+                        <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2Zm10-10V7a4 4 0 0 0-8 0v4h8Z" />
+                            </svg>
+                        </div>
+                        <input
+                            id="new_password"
+                            name="new_password"
+                            type="password"
+                            placeholder="Sandi baru"
+                            class="block h-11 w-full rounded-md border border-slate-300 bg-white pl-9 pr-10 text-sm text-slate-700 outline-none transition focus:border-[#0b4a5a] focus:ring-2 focus:ring-[#0b4a5a]/10 placeholder:text-slate-400"
+                        />
+                        <button type="button" data-password-toggle="new_password" aria-label="Tampilkan sandi baru" class="absolute inset-y-0 right-0 flex items-center pr-3 text-slate-400 transition hover:text-[#0b4a5a]">
+                            <svg data-eye-open class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7Z" />
+                            </svg>
+                            <svg data-eye-closed class="hidden h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m3 3 18 18" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.584 10.587A2 2 0 0 0 12 14a2 2 0 0 0 1.414-.586" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.878 5.099A9.97 9.97 0 0 1 12 5c4.478 0 8.268 2.943 9.542 7a10.028 10.028 0 0 1-4.132 5.145M6.228 6.228A10.023 10.023 0 0 0 2.458 12c1.274 4.057 5.065 7 9.542 7a9.97 9.97 0 0 0 5.1-1.401" />
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+
+                <div class="space-y-1.5">
+                    <label for="new_password_confirmation" class="block text-sm font-bold text-slate-700">Konfirmasi Sandi</label>
+                    <div class="relative">
+                        <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+                            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 12 2 2 4-4" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3 5 6v5c0 4.5 2.9 8.7 7 10 4.1-1.3 7-5.5 7-10V6l-7-3Z" />
+                            </svg>
+                        </div>
+                        <input
+                            id="new_password_confirmation"
+                            name="new_password_confirmation"
+                            type="password"
+                            placeholder="Ulangi sandi baru"
+                            class="block h-11 w-full rounded-md border border-slate-300 bg-white pl-9 pr-10 text-sm text-slate-700 outline-none transition focus:border-[#0b4a5a] focus:ring-2 focus:ring-[#0b4a5a]/10 placeholder:text-slate-400"
+                        />
+                        <button type="button" data-password-toggle="new_password_confirmation" aria-label="Tampilkan konfirmasi sandi" class="absolute inset-y-0 right-0 flex items-center pr-3 text-slate-400 transition hover:text-[#0b4a5a]">
+                            <svg data-eye-open class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7Z" />
+                            </svg>
+                            <svg data-eye-closed class="hidden h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m3 3 18 18" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.584 10.587A2 2 0 0 0 12 14a2 2 0 0 0 1.414-.586" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.878 5.099A9.97 9.97 0 0 1 12 5c4.478 0 8.268 2.943 9.542 7a10.028 10.028 0 0 1-4.132 5.145M6.228 6.228A10.023 10.023 0 0 0 2.458 12c1.274 4.057 5.065 7 9.542 7a9.97 9.97 0 0 0 5.1-1.401" />
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <button type="button" class="h-11 w-full rounded-md bg-[#083d4b] text-sm font-bold text-white transition hover:bg-[#062f39]">
+                Reset Sandi Owner
+            </button>
+
+            <div class="text-center">
+                <a href="{{ route('password.request') }}" class="text-sm font-bold text-[#0b4a5a] hover:underline">
+                    Kembali ke info lupa kata sandi
+                </a>
+            </div>
+        </form>
+    </div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -254,6 +254,8 @@
 
         $pageTitle = trim($__env->yieldContent('page_title')) ?: ($judulHalaman ?? 'Dashboard');
         $pageSubtitle = trim($__env->yieldContent('page_subtitle')) ?: 'Workspace inventori untuk operasional toko mode lengkap.';
+        $showTopbarPageHeader = trim($__env->yieldContent('topbar_page_header')) !== 'false';
+        $hidePageHeader = trim($__env->yieldContent('hide_page_header')) !== 'false';
         $feedbackToasts = collect([
             ['type' => 'success', 'message' => session('success')],
             ['type' => 'success', 'message' => session('status')],
@@ -397,8 +399,8 @@
         </aside>
 
         <div class="flex min-w-0 flex-1 flex-col">
-            <header class="sticky top-0 z-30 border-b border-[#d6dde1] bg-[#f8fafb]/96 shadow-[0_10px_28px_-22px_rgba(15,39,48,0.48)] backdrop-blur">
-                <div class="flex items-center justify-between gap-4 px-5 py-4 sm:px-8">
+            <header class="sticky top-0 z-30 border-b border-[#d6dde1] bg-gradient-to-r from-[#f8fafb]/98 via-white/96 to-[#eef5f7]/95 shadow-[0_10px_28px_-22px_rgba(15,39,48,0.48)] backdrop-blur">
+                <div class="flex min-h-[4.75rem] items-center justify-between gap-3 px-4 py-3 sm:gap-4 sm:px-8">
                     <div class="flex min-w-0 flex-1 items-center gap-3 sm:gap-4">
                         <button
                             type="button"
@@ -411,15 +413,30 @@
                             </svg>
                         </button>
 
-                        <div class="sm:hidden">
-                            <p class="text-xl font-extrabold tracking-tight text-[#003441]">Sitori</p>
-                            <p class="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">
+                        <div class="min-w-0 sm:hidden">
+                            <p class="truncate text-base font-extrabold tracking-tight text-[#003441]">{{ $pageTitle }}</p>
+                            <p class="truncate text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">
                                 {{ $role === 'owner' && $modeApp === 'lengkap' ? 'Mode Monitoring' : ($modeApp === 'lengkap' ? 'Mode Lengkap' : 'Workspace Toko') }}
                             </p>
                         </div>
+
+                        @if ($showTopbarPageHeader)
+                            <div class="hidden min-w-0 items-center gap-4 lg:flex">
+                                <span class="h-10 w-1.5 shrink-0 rounded-full bg-gradient-to-b from-[#0f4c5c] to-[#8ac7d8] shadow-[0_10px_22px_-14px_rgba(15,76,92,0.9)]"></span>
+                                <div class="min-w-0">
+                                    <div class="flex items-center gap-2">
+                                        <span class="rounded-full border border-[#d6dde1] bg-white/80 px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.18em] text-[#0f4c5c]">
+                                            {{ $role === 'owner' && $modeApp === 'lengkap' ? 'Monitoring' : ($modeApp === 'lengkap' ? 'Mode Lengkap' : 'Workspace') }}
+                                        </span>
+                                    </div>
+                                    <h1 class="mt-1 truncate text-[1.35rem] font-extrabold leading-tight tracking-tight text-slate-900">{{ $pageTitle }}</h1>
+                                    <p class="mt-0.5 max-w-[min(58vw,56rem)] truncate text-sm leading-5 text-slate-500">{{ $pageSubtitle }}</p>
+                                </div>
+                            </div>
+                        @endif
                     </div>
 
-                    <div class="flex items-center gap-2 rounded-full border border-[#d8dee2] bg-white/88 px-2 py-1.5 shadow-[0_12px_28px_-22px_rgba(15,39,48,0.55)] sm:gap-3 sm:px-3">
+                    <div class="flex shrink-0 items-center gap-1.5 rounded-full border border-[#d8dee2] bg-white/90 px-1.5 py-1.5 shadow-[0_12px_28px_-22px_rgba(15,39,48,0.55)] sm:gap-2 sm:px-2">
                         @if (in_array($role, ['owner', 'gudang'], true))
                         <details class="relative">
                             <summary
@@ -479,7 +496,7 @@
                         @if (in_array($role, ['owner', 'gudang'], true))
                         <div class="hidden h-8 w-px bg-[#d8dee2] sm:block"></div>
                         @endif
-                        <div class="flex items-center gap-3 rounded-full px-2 py-1 transition hover:bg-[#f3f4f5]">
+                        <div class="flex items-center gap-3 rounded-full px-1.5 py-1 transition hover:bg-[#f3f4f5] sm:px-2">
                             <div class="hidden text-right sm:block">
                                 <p class="text-sm font-semibold text-slate-800">{{ $user?->name ?? 'Owner Admin' }}</p>
                                 <p class="text-xs text-slate-500">{{ $user?->store_name ?? 'Sitori Workspace' }}</p>
@@ -493,17 +510,23 @@
             </header>
 
             <main class="flex-1 p-4 sm:p-6 lg:p-8" data-app-main>
-                <div class="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                    <div class="min-w-0">
-                        <h1 class="text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl">{{ $pageTitle }}</h1>
-                        <p class="mt-2 max-w-3xl text-sm leading-6 text-slate-500">{{ $pageSubtitle }}</p>
-                    </div>
-                    @hasSection('page_actions')
-                        <div class="flex w-full flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end lg:w-auto" data-page-actions>
-                            @yield('page_actions')
+                @if (! $hidePageHeader)
+                    <div class="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                        <div class="min-w-0">
+                            <h1 class="text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl">{{ $pageTitle }}</h1>
+                            <p class="mt-2 max-w-3xl text-sm leading-6 text-slate-500">{{ $pageSubtitle }}</p>
                         </div>
-                    @endif
-                </div>
+                        @hasSection('page_actions')
+                            <div class="flex w-full flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end lg:w-auto" data-page-actions>
+                                @yield('page_actions')
+                            </div>
+                        @endif
+                    </div>
+                @elseif($__env->hasSection('page_actions'))
+                    <div class="mb-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end" data-page-actions>
+                        @yield('page_actions')
+                    </div>
+                @endif
 
                 @yield('content')
             </main>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,9 @@ use App\Http\Controllers\TransactionController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
+Route::get('/lupa-kata-sandi', [AuthController::class, 'showForgotPasswordForm'])->name('password.request');
+Route::get('/reset-sandi-owner', [AuthController::class, 'showOwnerPasswordResetForm'])->name('password.owner-reset');
+
 Route::middleware('guest')->group(function (): void {
     Route::get('/login', [AuthController::class, 'showLoginForm'])->name('login');
     Route::post('/login', [AuthController::class, 'login'])->name('login.process');


### PR DESCRIPTION
 Commit b9798fb berisi perubahan berikut:

  - Menambahkan halaman Lupa Kata Sandi khusus owner, lengkap dengan ikon gembok, peringatan bahwa pegawai harus menghubungi owner, dan tombol lanjut
    reset sandi owner.

  - Menambahkan halaman Reset Sandi Owner sebagai desain FE-only, berisi input email owner, kode verifikasi, sandi baru, dan konfirmasi sandi.
  - Menghubungkan link “Lupa kata sandi?” dari halaman login ke halaman lupa sandi.
  - Menambahkan route baru untuk /lupa-kata-sandi dan /reset-sandi-owner.
  - Memindahkan judul dan deskripsi semua halaman aplikasi ke topbar agar area konten lebih bersih.
  - Memoles topbar dengan gradient halus, badge mode, aksen visual, truncate subtitle, dan tampilan mobile yang lebih ringkas.